### PR TITLE
Enhanced type casting from Time to Date

### DIFF
--- a/lib/redis/recurring_at_intervals.rb
+++ b/lib/redis/recurring_at_intervals.rb
@@ -30,10 +30,10 @@ class Redis
 
     def range(start_date_or_time, end_date_or_time)
       keys = []
-      date_or_time = start_date_or_time
+      date_or_time = normalize(start_date_or_time)
 
       loop do
-        break if date_or_time > end_date_or_time
+        break if date_or_time > normalize(end_date_or_time)
 
         keys << redis_periodical_field_key(date_or_time)
         date_or_time = next_key(date_or_time)
@@ -72,8 +72,12 @@ class Redis
       raise 'not implemented'
     end
 
-    def next_key(_date, _length = 1)
+    def next_key(_date_or_time, _length = 1)
       raise 'not implemented'
+    end
+
+    def normalize(date_or_time)
+      next_key(date_or_time, 0)
     end
   end
 end

--- a/lib/redis/recurring_at_intervals.rb
+++ b/lib/redis/recurring_at_intervals.rb
@@ -4,7 +4,7 @@ class Redis
   module RecurringAtIntervals
     def initialize(key, *args)
       @original_key = key
-      super(redis_daily_field_key(current_time), *args)
+      super(redis_periodical_field_key(current_time), *args)
     end
 
     attr_reader :original_key
@@ -19,13 +19,13 @@ class Redis
         when -1 then nil  # Ruby does this (a bit weird)
         end
       else
-        get_value_from_redis(redis_daily_field_key(date_or_time))
+        get_value_from_redis(redis_periodical_field_key(date_or_time))
       end
     end
     alias slice []
 
     def delete_at(date_or_time)
-      delete_from_redis(redis_daily_field_key(date_or_time))
+      delete_from_redis(redis_periodical_field_key(date_or_time))
     end
 
     def range(start_date_or_time, end_date_or_time)
@@ -35,7 +35,7 @@ class Redis
       loop do
         break if date_or_time > end_date_or_time
 
-        keys << redis_daily_field_key(date_or_time)
+        keys << redis_periodical_field_key(date_or_time)
         date_or_time = next_key(date_or_time)
       end
 
@@ -43,7 +43,7 @@ class Redis
     end
 
     def at(date_or_time)
-      get_redis_object(redis_daily_field_key(date_or_time))
+      get_redis_object(redis_periodical_field_key(date_or_time))
     end
 
     def current_time
@@ -68,7 +68,7 @@ class Redis
       raise 'not implemented'
     end
 
-    def redis_daily_field_key(_date_or_time)
+    def redis_periodical_field_key(_date_or_time)
       raise 'not implemented'
     end
 

--- a/lib/redis/recurring_at_intervals/annual.rb
+++ b/lib/redis/recurring_at_intervals/annual.rb
@@ -5,7 +5,7 @@ class Redis
     module Annual
       private
 
-      def redis_daily_field_key(date_or_time)
+      def redis_periodical_field_key(date_or_time)
         date_key = date_or_time.strftime('%Y')
         [original_key, date_key].flatten.join(':')
       end

--- a/lib/redis/recurring_at_intervals/annual.rb
+++ b/lib/redis/recurring_at_intervals/annual.rb
@@ -10,8 +10,8 @@ class Redis
         [original_key, date_key].flatten.join(':')
       end
 
-      def next_key(date, length = 1)
-        date.next_year(length)
+      def next_key(date_or_time, length = 1)
+        date_or_time.to_date.next_year(length)
       end
     end
   end

--- a/lib/redis/recurring_at_intervals/daily.rb
+++ b/lib/redis/recurring_at_intervals/daily.rb
@@ -5,7 +5,7 @@ class Redis
     module Daily
       private
 
-      def redis_daily_field_key(date_or_time)
+      def redis_periodical_field_key(date_or_time)
         date_key = date_or_time.strftime('%Y-%m-%d')
         [original_key, date_key].flatten.join(':')
       end

--- a/lib/redis/recurring_at_intervals/daily.rb
+++ b/lib/redis/recurring_at_intervals/daily.rb
@@ -10,8 +10,8 @@ class Redis
         [original_key, date_key].flatten.join(':')
       end
 
-      def next_key(date, length = 1)
-        date + length
+      def next_key(date_or_time, length = 1)
+        date_or_time.to_date + length
       end
     end
   end

--- a/lib/redis/recurring_at_intervals/hourly.rb
+++ b/lib/redis/recurring_at_intervals/hourly.rb
@@ -5,7 +5,7 @@ class Redis
     module Hourly
       private
 
-      def redis_daily_field_key(time)
+      def redis_periodical_field_key(time)
         time_key = time.strftime('%Y-%m-%dT%H')
         [original_key, time_key].flatten.join(':')
       end

--- a/lib/redis/recurring_at_intervals/minutely.rb
+++ b/lib/redis/recurring_at_intervals/minutely.rb
@@ -5,7 +5,7 @@ class Redis
     module Minutely
       private
 
-      def redis_daily_field_key(time)
+      def redis_periodical_field_key(time)
         time_key = time.strftime('%Y-%m-%dT%H:%M')
         [original_key, time_key].flatten.join(':')
       end

--- a/lib/redis/recurring_at_intervals/monthly.rb
+++ b/lib/redis/recurring_at_intervals/monthly.rb
@@ -10,8 +10,8 @@ class Redis
         [original_key, date_key].flatten.join(':')
       end
 
-      def next_key(date, length = 1)
-        date.next_month(length)
+      def next_key(date_or_time, length = 1)
+        date_or_time.to_date.next_month(length)
       end
     end
   end

--- a/lib/redis/recurring_at_intervals/monthly.rb
+++ b/lib/redis/recurring_at_intervals/monthly.rb
@@ -5,7 +5,7 @@ class Redis
     module Monthly
       private
 
-      def redis_daily_field_key(date_or_time)
+      def redis_periodical_field_key(date_or_time)
         date_key = date_or_time.strftime('%Y-%m')
         [original_key, date_key].flatten.join(':')
       end

--- a/lib/redis/recurring_at_intervals/weekly.rb
+++ b/lib/redis/recurring_at_intervals/weekly.rb
@@ -10,8 +10,8 @@ class Redis
         [original_key, date_key].flatten.join(':')
       end
 
-      def next_key(date, length = 1)
-        date + 7 * length
+      def next_key(date_or_time, length = 1)
+        date_or_time.to_date + 7 * length
       end
     end
   end

--- a/lib/redis/recurring_at_intervals/weekly.rb
+++ b/lib/redis/recurring_at_intervals/weekly.rb
@@ -5,7 +5,7 @@ class Redis
     module Weekly
       private
 
-      def redis_daily_field_key(date_or_time)
+      def redis_periodical_field_key(date_or_time)
         date_key = date_or_time.strftime('%YW%W')
         [original_key, date_key].flatten.join(':')
       end

--- a/spec/lib/redis/annual_counter_spec.rb
+++ b/spec/lib/redis/annual_counter_spec.rb
@@ -94,6 +94,14 @@ RSpec.describe Redis::AnnualCounter do
       end
     end
 
+    context 'with date and length (zero)' do
+      let(:date) { Date.new(2022, 4, 1) }
+
+      it 'returns an empty array' do
+        expect(homepage.pv[date, 0]).to eq []
+      end
+    end
+
     context 'with range of date' do
       let(:range) do
         Date.new(2021, 4, 1)..Date.new(2022, 4, 1)
@@ -117,6 +125,14 @@ RSpec.describe Redis::AnnualCounter do
 
       it 'returns the values counted within the duration' do
         expect(homepage.pv[time, 2]).to eq [11, 12]
+      end
+    end
+
+    context 'with time and length (zero)' do
+      let(:time) { Time.local(2022, 4, 1, 10, 20, 30) }
+
+      it 'returns an empty array' do
+        expect(homepage.pv[time, 0]).to eq []
       end
     end
 

--- a/spec/lib/redis/annual_counter_spec.rb
+++ b/spec/lib/redis/annual_counter_spec.rb
@@ -94,9 +94,35 @@ RSpec.describe Redis::AnnualCounter do
       end
     end
 
-    context 'with range' do
+    context 'with range of date' do
       let(:range) do
         Date.new(2021, 4, 1)..Date.new(2022, 4, 1)
+      end
+
+      it 'returns the values counted within the duration' do
+        expect(homepage.pv[range]).to eq [10, 11]
+      end
+    end
+
+    context 'with time' do
+      let(:time) { Time.local(2021, 4, 1, 10, 20, 30) }
+
+      it 'returns the value counted the year' do
+        expect(homepage.pv[time]).to eq 10
+      end
+    end
+
+    context 'with time and length' do
+      let(:time) { Time.local(2022, 4, 1, 10, 20, 30) }
+
+      it 'returns the values counted within the duration' do
+        expect(homepage.pv[time, 2]).to eq [11, 12]
+      end
+    end
+
+    context 'with range of time' do
+      let(:range) do
+        Time.local(2021, 4, 1, 10, 20, 30)..Time.local(2022, 4, 1, 10, 20, 30)
       end
 
       it 'returns the values counted within the duration' do
@@ -106,28 +132,62 @@ RSpec.describe Redis::AnnualCounter do
   end
 
   describe '#delete_at' do
-    it 'deletes the value on the year' do
-      date = Date.new(2022, 4, 1)
-      expect { homepage.pv.delete_at(date) }
-        .to change { homepage.pv.at(date) }
-        .from(11).to(0)
+    context 'with date' do
+      let(:date) { Date.new(2022, 4, 1) }
+
+      it 'deletes the value on the year' do
+        expect { homepage.pv.delete_at(date) }
+          .to change { homepage.pv.at(date) }
+          .from(11).to(0)
+      end
+    end
+
+    context 'with time' do
+      let(:time) { Time.local(2022, 4, 1, 10, 20, 30) }
+
+      it 'deletes the value on the year' do
+        expect { homepage.pv.delete_at(time) }
+          .to change { homepage.pv.at(time) }
+          .from(11).to(0)
+      end
     end
   end
 
   describe '#range' do
-    let(:start_date) { Date.new(2021, 4, 1) }
-    let(:end_date) { Date.new(2022, 4, 1) }
+    context 'with date' do
+      let(:start_date) { Date.new(2021, 4, 1) }
+      let(:end_date) { Date.new(2022, 4, 1) }
 
-    it 'returns the values counted within the duration' do
-      expect(homepage.pv.range(start_date, end_date)).to eq [10, 11]
+      it 'returns the values counted within the duration' do
+        expect(homepage.pv.range(start_date, end_date)).to eq [10, 11]
+      end
+    end
+
+    context 'with time' do
+      let(:start_time) { Time.local(2021, 4, 1, 10, 20, 30) }
+      let(:end_time) { Time.local(2022, 4, 1, 10, 20, 30) }
+
+      it 'returns the values counted within the duration' do
+        expect(homepage.pv.range(start_time, end_time)).to eq [10, 11]
+      end
     end
   end
 
   describe '#at' do
-    let(:date) { Date.new(2022, 4, 1) }
+    context 'with date' do
+      let(:date) { Date.new(2022, 4, 1) }
 
-    it 'returns a counter object counted the year' do
-      expect(homepage.pv.at(date).value).to eq 11
+      it 'returns a counter object counted the year' do
+        expect(homepage.pv.at(date).value).to eq 11
+      end
+    end
+
+    context 'with time' do
+      let(:time) { Time.local(2022, 4, 1, 10, 20, 30) }
+
+      it 'returns a counter object counted the year' do
+        expect(homepage.pv.at(time).value).to eq 11
+      end
     end
   end
 end

--- a/spec/lib/redis/annual_hash_key_spec.rb
+++ b/spec/lib/redis/annual_hash_key_spec.rb
@@ -102,6 +102,14 @@ RSpec.describe Redis::AnnualHashKey do
       end
     end
 
+    context 'with date and length (zero)' do
+      let(:date) { Date.new(2022, 4, 1) }
+
+      it 'returns an empty hash' do
+        expect(homepage.browsing_history[date, 0]).to eq({})
+      end
+    end
+
     context 'with range of date' do
       let(:range) do
         Date.new(2021, 4, 1)..Date.new(2022, 4, 1)
@@ -127,6 +135,14 @@ RSpec.describe Redis::AnnualHashKey do
       it 'returns the fields counted within the duration' do
         expect(homepage.browsing_history[time, 2])
           .to eq({ 'item1' => '3', 'item2' => 'a,1', 'item3' => '7', 'item4' => '1' })
+      end
+    end
+
+    context 'with time and length (zero)' do
+      let(:time) { Time.local(2022, 4, 1, 10, 20, 30) }
+
+      it 'returns an empty hash' do
+        expect(homepage.browsing_history[time, 0]).to eq({})
       end
     end
 

--- a/spec/lib/redis/annual_hash_key_spec.rb
+++ b/spec/lib/redis/annual_hash_key_spec.rb
@@ -102,9 +102,37 @@ RSpec.describe Redis::AnnualHashKey do
       end
     end
 
-    context 'with range' do
+    context 'with range of date' do
       let(:range) do
         Date.new(2021, 4, 1)..Date.new(2022, 4, 1)
+      end
+
+      it 'returns the values counted within the duration' do
+        expect(homepage.browsing_history[range])
+          .to eq({ 'item1' => '4.5', 'item2' => '2,a', 'item3' => '5' })
+      end
+    end
+
+    context 'with time' do
+      let(:time) { Time.local(2021, 4, 1, 10, 20, 30) }
+
+      it 'returns the field counted the year' do
+        expect(homepage.browsing_history[time]).to eq({ 'item1' => '1.5', 'item2' => '2' })
+      end
+    end
+
+    context 'with time and length' do
+      let(:time) { Time.local(2022, 4, 1, 10, 20, 30) }
+
+      it 'returns the fields counted within the duration' do
+        expect(homepage.browsing_history[time, 2])
+          .to eq({ 'item1' => '3', 'item2' => 'a,1', 'item3' => '7', 'item4' => '1' })
+      end
+    end
+
+    context 'with range of time' do
+      let(:range) do
+        Time.local(2021, 4, 1, 10, 20, 30)..Time.local(2022, 4, 1, 10, 20, 30)
       end
 
       it 'returns the values counted within the duration' do
@@ -115,30 +143,66 @@ RSpec.describe Redis::AnnualHashKey do
   end
 
   describe '#delete_at' do
-    it 'deletes the hash on the year' do
-      date = Date.new(2022, 4, 1)
-      expect { homepage.browsing_history.delete_at(date) }
-        .to change { homepage.browsing_history.at(date) }
-        .from({ 'item1' => '3', 'item2' => 'a', 'item3' => '5' }).to({})
+    context 'with date' do
+      let(:date) { Date.new(2022, 4, 1) }
+
+      it 'deletes the hash on the year' do
+        expect { homepage.browsing_history.delete_at(date) }
+          .to change { homepage.browsing_history.at(date) }
+          .from({ 'item1' => '3', 'item2' => 'a', 'item3' => '5' }).to({})
+      end
+    end
+
+    context 'with time' do
+      let(:time) { Time.local(2022, 4, 1, 10, 20, 30) }
+
+      it 'deletes the hash on the year' do
+        expect { homepage.browsing_history.delete_at(time) }
+          .to change { homepage.browsing_history.at(time) }
+          .from({ 'item1' => '3', 'item2' => 'a', 'item3' => '5' }).to({})
+      end
     end
   end
 
   describe '#range' do
-    let(:start_date) { Date.new(2021, 4, 1) }
-    let(:end_date) { Date.new(2022, 4, 1) }
+    context 'with date' do
+      let(:start_date) { Date.new(2021, 4, 1) }
+      let(:end_date) { Date.new(2022, 4, 1) }
 
-    it 'returns the hash counted within the duration' do
-      expect(homepage.browsing_history.range(start_date, end_date))
-        .to eq({ 'item1' => '4.5', 'item2' => '2,a', 'item3' => '5' })
+      it 'returns the hash counted within the duration' do
+        expect(homepage.browsing_history.range(start_date, end_date))
+          .to eq({ 'item1' => '4.5', 'item2' => '2,a', 'item3' => '5' })
+      end
+    end
+
+    context 'with time' do
+      let(:start_time) { Time.local(2021, 4, 1, 10, 20, 30) }
+      let(:end_time) { Time.local(2022, 4, 1, 10, 20, 30) }
+
+      it 'returns the hash counted within the duration' do
+        expect(homepage.browsing_history.range(start_time, end_time))
+          .to eq({ 'item1' => '4.5', 'item2' => '2,a', 'item3' => '5' })
+      end
     end
   end
 
   describe '#at' do
-    let(:date) { Date.new(2022, 4, 1) }
+    context 'with date' do
+      let(:date) { Date.new(2022, 4, 1) }
 
-    it 'returns a counter object counted the year' do
-      expect(homepage.browsing_history.at(date).all)
-        .to eq({ 'item1' => '3', 'item2' => 'a', 'item3' => '5' })
+      it 'returns a counter object counted the year' do
+        expect(homepage.browsing_history.at(date).all)
+          .to eq({ 'item1' => '3', 'item2' => 'a', 'item3' => '5' })
+      end
+    end
+
+    context 'with time' do
+      let(:time) { Time.local(2022, 4, 1, 10, 20, 30) }
+
+      it 'returns a counter object counted the year' do
+        expect(homepage.browsing_history.at(time).all)
+          .to eq({ 'item1' => '3', 'item2' => 'a', 'item3' => '5' })
+      end
     end
   end
 end

--- a/spec/lib/redis/annual_set_spec.rb
+++ b/spec/lib/redis/annual_set_spec.rb
@@ -96,6 +96,14 @@ RSpec.describe Redis::AnnualSet do
       end
     end
 
+    context 'with date and length (zero)' do
+      let(:date) { Date.new(2022, 4, 1) }
+
+      it 'returns an empty array' do
+        expect(homepage.annual_active_users[date, 0]).to eq []
+      end
+    end
+
     context 'with range of date' do
       let(:range) do
         Date.new(2021, 4, 1)..Date.new(2022, 4, 1)
@@ -122,6 +130,14 @@ RSpec.describe Redis::AnnualSet do
       it 'returns the members added within the duration' do
         expect(homepage.annual_active_users[time, 2])
           .to contain_exactly('user1', 'user2', 'user3', 'user4', 'user5')
+      end
+    end
+
+    context 'with time and length (zero)' do
+      let(:time) { Time.local(2022, 4, 1, 10, 20, 30) }
+
+      it 'returns an empty array' do
+        expect(homepage.annual_active_users[time, 0]).to eq []
       end
     end
 

--- a/spec/lib/redis/annual_set_spec.rb
+++ b/spec/lib/redis/annual_set_spec.rb
@@ -96,9 +96,38 @@ RSpec.describe Redis::AnnualSet do
       end
     end
 
-    context 'with range' do
+    context 'with range of date' do
       let(:range) do
         Date.new(2021, 4, 1)..Date.new(2022, 4, 1)
+      end
+
+      it 'returns the members counted within the duration' do
+        expect(homepage.annual_active_users[range])
+          .to contain_exactly('user1', 'user2', 'user3', 'user4', 'user5')
+      end
+    end
+
+    context 'with time' do
+      let(:time) { Time.local(2021, 4, 1, 10, 20, 30) }
+
+      it 'returns the members added the year' do
+        expect(homepage.annual_active_users[time])
+          .to contain_exactly('user1', 'user2', 'user3')
+      end
+    end
+
+    context 'with time and length' do
+      let(:time) { Time.local(2022, 4, 1, 10, 20, 30) }
+
+      it 'returns the members added within the duration' do
+        expect(homepage.annual_active_users[time, 2])
+          .to contain_exactly('user1', 'user2', 'user3', 'user4', 'user5')
+      end
+    end
+
+    context 'with range of time' do
+      let(:range) do
+        Time.local(2021, 4, 1, 10, 20, 30)..Time.local(2022, 4, 1, 10, 20, 30)
       end
 
       it 'returns the members counted within the duration' do
@@ -109,32 +138,70 @@ RSpec.describe Redis::AnnualSet do
   end
 
   describe '#delete_at' do
-    it 'deletes the members on the year' do
-      date = Date.new(2022, 4, 1)
-      expect { homepage.annual_active_users.delete_at(date) }
-        .to change { homepage.annual_active_users.at(date).length }
-        .from(4).to(0)
+    context 'with date' do
+      let(:date) { Date.new(2022, 4, 1) }
+
+      it 'deletes the members on the year' do
+        expect { homepage.annual_active_users.delete_at(date) }
+          .to change { homepage.annual_active_users.at(date).length }
+          .from(4).to(0)
+      end
+    end
+
+    context 'with time' do
+      let(:time) { Time.local(2022, 4, 1, 10, 20, 30) }
+
+      it 'deletes the members on the year' do
+        expect { homepage.annual_active_users.delete_at(time) }
+          .to change { homepage.annual_active_users.at(time).length }
+          .from(4).to(0)
+      end
     end
   end
 
   describe '#range' do
-    let(:start_date) { Date.new(2021, 4, 1) }
-    let(:end_date) { Date.new(2022, 4, 1) }
+    context 'with date' do
+      let(:start_date) { Date.new(2021, 4, 1) }
+      let(:end_date) { Date.new(2022, 4, 1) }
 
-    it 'returns the members added within the duration' do
-      expect(homepage.annual_active_users.range(start_date, end_date))
-        .to contain_exactly('user1', 'user2', 'user3', 'user4', 'user5')
+      it 'returns the members added within the duration' do
+        expect(homepage.annual_active_users.range(start_date, end_date))
+          .to contain_exactly('user1', 'user2', 'user3', 'user4', 'user5')
+      end
+    end
+
+    context 'with time' do
+      let(:start_time) { Time.local(2021, 4, 1, 10, 20, 30) }
+      let(:end_time) { Time.local(2022, 4, 1, 10, 20, 30) }
+
+      it 'returns the members added within the duration' do
+        expect(homepage.annual_active_users.range(start_time, end_time))
+          .to contain_exactly('user1', 'user2', 'user3', 'user4', 'user5')
+      end
     end
   end
 
   describe '#at' do
-    let(:date) { Date.new(2022, 4, 1) }
+    context 'with date' do
+      let(:date) { Date.new(2022, 4, 1) }
 
-    it 'returns a set object added the year' do
-      expect(homepage.annual_active_users.at(date).members)
-        .to contain_exactly('user1', 'user2', 'user4', 'user5')
-      expect(homepage.annual_active_users.at(date).length)
-        .to eq 4
+      it 'returns a set object added the year' do
+        expect(homepage.annual_active_users.at(date).members)
+          .to contain_exactly('user1', 'user2', 'user4', 'user5')
+        expect(homepage.annual_active_users.at(date).length)
+          .to eq 4
+      end
+    end
+
+    context 'with time' do
+      let(:time) { Time.local(2022, 4, 1, 10, 20, 30) }
+
+      it 'returns a set object added the year' do
+        expect(homepage.annual_active_users.at(time).members)
+          .to contain_exactly('user1', 'user2', 'user4', 'user5')
+        expect(homepage.annual_active_users.at(time).length)
+          .to eq 4
+      end
     end
   end
 end

--- a/spec/lib/redis/daily_counter_spec.rb
+++ b/spec/lib/redis/daily_counter_spec.rb
@@ -92,6 +92,14 @@ RSpec.describe Redis::DailyCounter do
       end
     end
 
+    context 'with date and length (zero)' do
+      let(:date) { Date.new(2021, 4, 2) }
+
+      it 'returns an empty array' do
+        expect(homepage.pv[date, 0]).to eq []
+      end
+    end
+
     context 'with range of date' do
       let(:range) do
         Date.new(2021, 4, 1)..Date.new(2021, 4, 2)
@@ -115,6 +123,14 @@ RSpec.describe Redis::DailyCounter do
 
       it 'returns the values counted within the duration' do
         expect(homepage.pv[time, 2]).to eq [11, 12]
+      end
+    end
+
+    context 'with time and length (zero)' do
+      let(:time) { Time.local(2021, 4, 2, 10, 20, 30) }
+
+      it 'returns an empty array' do
+        expect(homepage.pv[time, 0]).to eq []
       end
     end
 

--- a/spec/lib/redis/daily_counter_spec.rb
+++ b/spec/lib/redis/daily_counter_spec.rb
@@ -92,9 +92,35 @@ RSpec.describe Redis::DailyCounter do
       end
     end
 
-    context 'with range' do
+    context 'with range of date' do
       let(:range) do
         Date.new(2021, 4, 1)..Date.new(2021, 4, 2)
+      end
+
+      it 'returns the values counted within the duration' do
+        expect(homepage.pv[range]).to eq [10, 11]
+      end
+    end
+
+    context 'with time' do
+      let(:time) { Time.local(2021, 4, 1, 10, 20, 30) }
+
+      it 'returns the value counted the day' do
+        expect(homepage.pv[time]).to eq 10
+      end
+    end
+
+    context 'with time and length' do
+      let(:time) { Time.local(2021, 4, 2, 10, 20, 30) }
+
+      it 'returns the values counted within the duration' do
+        expect(homepage.pv[time, 2]).to eq [11, 12]
+      end
+    end
+
+    context 'with range of time' do
+      let(:range) do
+        Time.local(2021, 4, 1, 10, 20, 30)..Time.local(2021, 4, 2, 10, 20, 30)
       end
 
       it 'returns the values counted within the duration' do
@@ -104,28 +130,62 @@ RSpec.describe Redis::DailyCounter do
   end
 
   describe '#delete_at' do
-    it 'deletes the value on the day' do
-      date = Date.new(2021, 4, 2)
-      expect { homepage.pv.delete_at(date) }
-        .to change { homepage.pv.at(date) }
-        .from(11).to(0)
+    context 'with date' do
+      let(:date) { Date.new(2021, 4, 2) }
+
+      it 'deletes the value on the day' do
+        expect { homepage.pv.delete_at(date) }
+          .to change { homepage.pv.at(date) }
+          .from(11).to(0)
+      end
+    end
+
+    context 'with time' do
+      let(:time) { Time.local(2021, 4, 2, 10, 20, 30) }
+
+      it 'deletes the value on the day' do
+        expect { homepage.pv.delete_at(time) }
+          .to change { homepage.pv.at(time) }
+          .from(11).to(0)
+      end
     end
   end
 
   describe '#range' do
-    let(:start_date) { Date.new(2021, 4, 1) }
-    let(:end_date) { Date.new(2021, 4, 2) }
+    context 'with date' do
+      let(:start_date) { Date.new(2021, 4, 1) }
+      let(:end_date) { Date.new(2021, 4, 2) }
 
-    it 'returns the values counted within the duration' do
-      expect(homepage.pv.range(start_date, end_date)).to eq [10, 11]
+      it 'returns the values counted within the duration' do
+        expect(homepage.pv.range(start_date, end_date)).to eq [10, 11]
+      end
+    end
+
+    context 'with time' do
+      let(:start_time) { Time.local(2021, 4, 1, 10, 20, 30) }
+      let(:end_time) { Time.local(2021, 4, 2, 10, 20, 30) }
+
+      it 'returns the values counted within the duration' do
+        expect(homepage.pv.range(start_time, end_time)).to eq [10, 11]
+      end
     end
   end
 
   describe '#at' do
-    let(:date) { Date.new(2021, 4, 2) }
+    context 'with date' do
+      let(:date) { Date.new(2021, 4, 2) }
 
-    it 'returns a counter object counted the day' do
-      expect(homepage.pv.at(date).value).to eq 11
+      it 'returns a counter object counted the day' do
+        expect(homepage.pv.at(date).value).to eq 11
+      end
+    end
+
+    context 'with time' do
+      let(:time) { Time.local(2021, 4, 2, 10, 20, 30) }
+
+      it 'returns a counter object counted the day' do
+        expect(homepage.pv.at(time).value).to eq 11
+      end
     end
   end
 end

--- a/spec/lib/redis/daily_hash_key_spec.rb
+++ b/spec/lib/redis/daily_hash_key_spec.rb
@@ -100,9 +100,37 @@ RSpec.describe Redis::DailyHashKey do
       end
     end
 
-    context 'with range' do
+    context 'with range of date' do
       let(:range) do
         Date.new(2021, 4, 1)..Date.new(2021, 4, 2)
+      end
+
+      it 'returns the values counted within the duration' do
+        expect(homepage.browsing_history[range])
+          .to eq({ 'item1' => '4.5', 'item2' => '2,a', 'item3' => '5' })
+      end
+    end
+
+    context 'with time' do
+      let(:time) { Time.local(2021, 4, 1, 10, 20, 30) }
+
+      it 'returns the field counted the year' do
+        expect(homepage.browsing_history[time]).to eq({ 'item1' => '1.5', 'item2' => '2' })
+      end
+    end
+
+    context 'with time and length' do
+      let(:time) { Time.local(2021, 4, 2, 10, 20, 30) }
+
+      it 'returns the fields counted within the duration' do
+        expect(homepage.browsing_history[time, 2])
+          .to eq({ 'item1' => '3', 'item2' => 'a,1', 'item3' => '7', 'item4' => '1' })
+      end
+    end
+
+    context 'with range of time' do
+      let(:range) do
+        Time.local(2021, 4, 1, 10, 20, 30)..Time.local(2021, 4, 2, 10, 20, 30)
       end
 
       it 'returns the values counted within the duration' do
@@ -113,30 +141,66 @@ RSpec.describe Redis::DailyHashKey do
   end
 
   describe '#delete_at' do
-    it 'deletes the hash on the year' do
-      date = Date.new(2021, 4, 2)
-      expect { homepage.browsing_history.delete_at(date) }
-        .to change { homepage.browsing_history.at(date) }
-        .from({ 'item1' => '3', 'item2' => 'a', 'item3' => '5' }).to({})
+    context 'with date' do
+      let(:date) { Date.new(2021, 4, 2) }
+
+      it 'deletes the hash on the year' do
+        expect { homepage.browsing_history.delete_at(date) }
+          .to change { homepage.browsing_history.at(date) }
+          .from({ 'item1' => '3', 'item2' => 'a', 'item3' => '5' }).to({})
+      end
+    end
+
+    context 'with time' do
+      let(:time) { Time.local(2021, 4, 2, 10, 20, 30) }
+
+      it 'deletes the hash on the year' do
+        expect { homepage.browsing_history.delete_at(time) }
+          .to change { homepage.browsing_history.at(time) }
+          .from({ 'item1' => '3', 'item2' => 'a', 'item3' => '5' }).to({})
+      end
     end
   end
 
   describe '#range' do
-    let(:start_date) { Date.new(2021, 4, 1) }
-    let(:end_date) { Date.new(2021, 4, 2) }
+    context 'with date' do
+      let(:start_date) { Date.new(2021, 4, 1) }
+      let(:end_date) { Date.new(2021, 4, 2) }
 
-    it 'returns the hash counted within the duration' do
-      expect(homepage.browsing_history.range(start_date, end_date))
-        .to eq({ 'item1' => '4.5', 'item2' => '2,a', 'item3' => '5' })
+      it 'returns the hash counted within the duration' do
+        expect(homepage.browsing_history.range(start_date, end_date))
+          .to eq({ 'item1' => '4.5', 'item2' => '2,a', 'item3' => '5' })
+      end
+    end
+
+    context 'with time' do
+      let(:start_time) { Time.local(2021, 4, 1, 10, 20, 30) }
+      let(:end_time) { Time.local(2021, 4, 2, 10, 20, 30) }
+
+      it 'returns the hash counted within the duration' do
+        expect(homepage.browsing_history.range(start_time, end_time))
+          .to eq({ 'item1' => '4.5', 'item2' => '2,a', 'item3' => '5' })
+      end
     end
   end
 
   describe '#at' do
-    let(:date) { Date.new(2021, 4, 2) }
+    context 'with date' do
+      let(:date) { Date.new(2021, 4, 2) }
 
-    it 'returns a counter object counted the year' do
-      expect(homepage.browsing_history.at(date).all)
-        .to eq({ 'item1' => '3', 'item2' => 'a', 'item3' => '5' })
+      it 'returns a counter object counted the year' do
+        expect(homepage.browsing_history.at(date).all)
+          .to eq({ 'item1' => '3', 'item2' => 'a', 'item3' => '5' })
+      end
+    end
+
+    context 'with time' do
+      let(:time) { Time.local(2021, 4, 2, 10, 20, 30) }
+
+      it 'returns a counter object counted the year' do
+        expect(homepage.browsing_history.at(time).all)
+          .to eq({ 'item1' => '3', 'item2' => 'a', 'item3' => '5' })
+      end
     end
   end
 end

--- a/spec/lib/redis/daily_hash_key_spec.rb
+++ b/spec/lib/redis/daily_hash_key_spec.rb
@@ -100,6 +100,14 @@ RSpec.describe Redis::DailyHashKey do
       end
     end
 
+    context 'with date and length (zero)' do
+      let(:date) { Date.new(2021, 4, 2) }
+
+      it 'returns an empty hash' do
+        expect(homepage.browsing_history[date, 0]).to eq({})
+      end
+    end
+
     context 'with range of date' do
       let(:range) do
         Date.new(2021, 4, 1)..Date.new(2021, 4, 2)
@@ -125,6 +133,14 @@ RSpec.describe Redis::DailyHashKey do
       it 'returns the fields counted within the duration' do
         expect(homepage.browsing_history[time, 2])
           .to eq({ 'item1' => '3', 'item2' => 'a,1', 'item3' => '7', 'item4' => '1' })
+      end
+    end
+
+    context 'with time and length (zero)' do
+      let(:time) { Time.local(2021, 4, 2, 10, 20, 30) }
+
+      it 'returns an empty hash' do
+        expect(homepage.browsing_history[time, 0]).to eq({})
       end
     end
 

--- a/spec/lib/redis/daily_set_spec.rb
+++ b/spec/lib/redis/daily_set_spec.rb
@@ -94,6 +94,14 @@ RSpec.describe Redis::DailySet do
       end
     end
 
+    context 'with date and length (zero)' do
+      let(:date) { Date.new(2021, 4, 2) }
+
+      it 'returns an empty array' do
+        expect(homepage.daily_active_users[date, 0]).to eq []
+      end
+    end
+
     context 'with range of date' do
       let(:range) do
         Date.new(2021, 4, 1)..Date.new(2021, 4, 2)
@@ -120,6 +128,14 @@ RSpec.describe Redis::DailySet do
       it 'returns the members added within the duration' do
         expect(homepage.daily_active_users[time, 2])
           .to contain_exactly('user1', 'user2', 'user3', 'user4', 'user5')
+      end
+    end
+
+    context 'with time and length (zero)' do
+      let(:time) { Time.local(2022, 4, 1, 10, 20, 30) }
+
+      it 'returns an empty array' do
+        expect(homepage.daily_active_users[time, 0]).to eq []
       end
     end
 

--- a/spec/lib/redis/daily_set_spec.rb
+++ b/spec/lib/redis/daily_set_spec.rb
@@ -94,9 +94,38 @@ RSpec.describe Redis::DailySet do
       end
     end
 
-    context 'with range' do
+    context 'with range of date' do
       let(:range) do
         Date.new(2021, 4, 1)..Date.new(2021, 4, 2)
+      end
+
+      it 'returns the members counted within the duration' do
+        expect(homepage.daily_active_users[range])
+          .to contain_exactly('user1', 'user2', 'user3', 'user4', 'user5')
+      end
+    end
+
+    context 'with time' do
+      let(:time) { Time.local(2021, 4, 1, 10, 20, 30) }
+
+      it 'returns the members added the day' do
+        expect(homepage.daily_active_users[time])
+          .to contain_exactly('user1', 'user2', 'user3')
+      end
+    end
+
+    context 'with time and length' do
+      let(:time) { Time.local(2021, 4, 2, 10, 20, 30) }
+
+      it 'returns the members added within the duration' do
+        expect(homepage.daily_active_users[time, 2])
+          .to contain_exactly('user1', 'user2', 'user3', 'user4', 'user5')
+      end
+    end
+
+    context 'with range of time' do
+      let(:range) do
+        Time.local(2021, 4, 1, 10, 20, 30)..Time.local(2021, 4, 2, 10, 20, 30)
       end
 
       it 'returns the members counted within the duration' do
@@ -107,32 +136,70 @@ RSpec.describe Redis::DailySet do
   end
 
   describe '#delete_at' do
-    it 'deletes the members on the day' do
-      date = Date.new(2021, 4, 2)
-      expect { homepage.daily_active_users.delete_at(date) }
-        .to change { homepage.daily_active_users.at(date).length }
-        .from(4).to(0)
+    context 'with date' do
+      let(:date) { Date.new(2021, 4, 2) }
+
+      it 'deletes the members on the day' do
+        expect { homepage.daily_active_users.delete_at(date) }
+          .to change { homepage.daily_active_users.at(date).length }
+          .from(4).to(0)
+      end
+    end
+
+    context 'with time' do
+      let(:time) { Time.local(2021, 4, 2, 10, 20, 30) }
+
+      it 'deletes the members on the day' do
+        expect { homepage.daily_active_users.delete_at(time) }
+          .to change { homepage.daily_active_users.at(time).length }
+          .from(4).to(0)
+      end
     end
   end
 
   describe '#range' do
-    let(:start_date) { Date.new(2021, 4, 1) }
-    let(:end_date) { Date.new(2021, 4, 2) }
+    context 'with date' do
+      let(:start_date) { Date.new(2021, 4, 1) }
+      let(:end_date) { Date.new(2021, 4, 2) }
 
-    it 'returns the members added within the duration' do
-      expect(homepage.daily_active_users.range(start_date, end_date))
-        .to contain_exactly('user1', 'user2', 'user3', 'user4', 'user5')
+      it 'returns the members added within the duration' do
+        expect(homepage.daily_active_users.range(start_date, end_date))
+          .to contain_exactly('user1', 'user2', 'user3', 'user4', 'user5')
+      end
+    end
+
+    context 'with time' do
+      let(:start_time) { Time.local(2021, 4, 1, 10, 20, 30) }
+      let(:end_time) { Time.local(2021, 4, 2, 10, 20, 30) }
+
+      it 'returns the members added within the duration' do
+        expect(homepage.daily_active_users.range(start_time, end_time))
+          .to contain_exactly('user1', 'user2', 'user3', 'user4', 'user5')
+      end
     end
   end
 
   describe '#at' do
-    let(:date) { Date.new(2021, 4, 2) }
+    context 'with date' do
+      let(:date) { Date.new(2021, 4, 2) }
 
-    it 'returns a set object added the day' do
-      expect(homepage.daily_active_users.at(date).members)
-        .to contain_exactly('user1', 'user2', 'user4', 'user5')
-      expect(homepage.daily_active_users.at(date).length)
-        .to eq 4
+      it 'returns a set object added the day' do
+        expect(homepage.daily_active_users.at(date).members)
+          .to contain_exactly('user1', 'user2', 'user4', 'user5')
+        expect(homepage.daily_active_users.at(date).length)
+          .to eq 4
+      end
+    end
+
+    context 'with time' do
+      let(:time) { Time.local(2021, 4, 2, 10, 20, 30) }
+
+      it 'returns a set object added the day' do
+        expect(homepage.daily_active_users.at(time).members)
+          .to contain_exactly('user1', 'user2', 'user4', 'user5')
+        expect(homepage.daily_active_users.at(time).length)
+          .to eq 4
+      end
     end
   end
 end

--- a/spec/lib/redis/hourly_counter_spec.rb
+++ b/spec/lib/redis/hourly_counter_spec.rb
@@ -76,19 +76,27 @@ RSpec.describe Redis::HourlyCounter do
   end
 
   describe '#[]' do
-    context 'with date' do
-      let(:date) { Time.local(2021, 4, 1, 10) }
+    context 'with time' do
+      let(:time) { Time.local(2021, 4, 1, 10) }
 
       it 'returns the value counted the hour' do
-        expect(homepage.pv[date]).to eq 10
+        expect(homepage.pv[time]).to eq 10
       end
     end
 
-    context 'with date and length' do
-      let(:date) { Time.local(2021, 4, 1, 11) }
+    context 'with time and length' do
+      let(:time) { Time.local(2021, 4, 1, 11) }
 
       it 'returns the values counted within the duration' do
-        expect(homepage.pv[date, 2]).to eq [11, 12]
+        expect(homepage.pv[time, 2]).to eq [11, 12]
+      end
+    end
+
+    context 'with time and length (zero)' do
+      let(:time) { Time.local(2021, 4, 1, 11) }
+
+      it 'returns an empty array' do
+        expect(homepage.pv[time, 0]).to eq []
       end
     end
 
@@ -104,28 +112,29 @@ RSpec.describe Redis::HourlyCounter do
   end
 
   describe '#delete_at' do
+    let(:time) { Time.local(2021, 4, 1, 11) }
+
     it 'deletes the value on the hour' do
-      date = Time.local(2021, 4, 1, 11)
-      expect { homepage.pv.delete_at(date) }
-        .to change { homepage.pv.at(date) }
+      expect { homepage.pv.delete_at(time) }
+        .to change { homepage.pv.at(time) }
         .from(11).to(0)
     end
   end
 
   describe '#range' do
-    let(:start_date) { Time.local(2021, 4, 1, 10) }
-    let(:end_date) { Time.local(2021, 4, 1, 11) }
+    let(:start_time) { Time.local(2021, 4, 1, 10) }
+    let(:end_time) { Time.local(2021, 4, 1, 11) }
 
     it 'returns the values counted within the duration' do
-      expect(homepage.pv.range(start_date, end_date)).to eq [10, 11]
+      expect(homepage.pv.range(start_time, end_time)).to eq [10, 11]
     end
   end
 
   describe '#at' do
-    let(:date) { Time.local(2021, 4, 1, 11) }
+    let(:time) { Time.local(2021, 4, 1, 11) }
 
     it 'returns a counter object counted the hour' do
-      expect(homepage.pv.at(date).value).to eq 11
+      expect(homepage.pv.at(time).value).to eq 11
     end
   end
 end

--- a/spec/lib/redis/hourly_hash_key_spec.rb
+++ b/spec/lib/redis/hourly_hash_key_spec.rb
@@ -83,20 +83,28 @@ RSpec.describe Redis::HourlyHashKey do
   end
 
   describe '#[]' do
-    context 'with date' do
-      let(:date) { Time.local(2021, 4, 1, 10) }
+    context 'with time' do
+      let(:time) { Time.local(2021, 4, 1, 10) }
 
       it 'returns the field counted the year' do
-        expect(homepage.browsing_history[date]).to eq({ 'item1' => '1.5', 'item2' => '2' })
+        expect(homepage.browsing_history[time]).to eq({ 'item1' => '1.5', 'item2' => '2' })
       end
     end
 
-    context 'with date and length' do
-      let(:date) { Time.local(2021, 4, 1, 11) }
+    context 'with time and length' do
+      let(:time) { Time.local(2021, 4, 1, 11) }
 
       it 'returns the fields counted within the duration' do
-        expect(homepage.browsing_history[date, 2])
+        expect(homepage.browsing_history[time, 2])
           .to eq({ 'item1' => '3', 'item2' => 'a,1', 'item3' => '7', 'item4' => '1' })
+      end
+    end
+
+    context 'with time and length (zero)' do
+      let(:time) { Time.local(2021, 4, 1, 11) }
+
+      it 'returns an empty hash' do
+        expect(homepage.browsing_history[time, 0]).to eq({})
       end
     end
 
@@ -113,29 +121,30 @@ RSpec.describe Redis::HourlyHashKey do
   end
 
   describe '#delete_at' do
+    let(:time) { Time.local(2021, 4, 1, 11) }
+
     it 'deletes the hash on the year' do
-      date = Time.local(2021, 4, 1, 11)
-      expect { homepage.browsing_history.delete_at(date) }
-        .to change { homepage.browsing_history.at(date) }
+      expect { homepage.browsing_history.delete_at(time) }
+        .to change { homepage.browsing_history.at(time) }
         .from({ 'item1' => '3', 'item2' => 'a', 'item3' => '5' }).to({})
     end
   end
 
   describe '#range' do
-    let(:start_date) { Time.local(2021, 4, 1, 10) }
-    let(:end_date) { Time.local(2021, 4, 1, 11) }
+    let(:start_time) { Time.local(2021, 4, 1, 10) }
+    let(:end_time) { Time.local(2021, 4, 1, 11) }
 
     it 'returns the hash counted within the duration' do
-      expect(homepage.browsing_history.range(start_date, end_date))
+      expect(homepage.browsing_history.range(start_time, end_time))
         .to eq({ 'item1' => '4.5', 'item2' => '2,a', 'item3' => '5' })
     end
   end
 
   describe '#at' do
-    let(:date) { Time.local(2021, 4, 1, 11) }
+    let(:time) { Time.local(2021, 4, 1, 11) }
 
     it 'returns a counter object counted the year' do
-      expect(homepage.browsing_history.at(date).all)
+      expect(homepage.browsing_history.at(time).all)
         .to eq({ 'item1' => '3', 'item2' => 'a', 'item3' => '5' })
     end
   end

--- a/spec/lib/redis/hourly_set_spec.rb
+++ b/spec/lib/redis/hourly_set_spec.rb
@@ -76,21 +76,29 @@ RSpec.describe Redis::HourlySet do
   end
 
   describe '#[]' do
-    context 'with date' do
-      let(:date) { Time.local(2021, 4, 1, 10) }
+    context 'with time' do
+      let(:time) { Time.local(2021, 4, 1, 10) }
 
       it 'returns the members added the hour' do
-        expect(homepage.hourly_active_users[date])
+        expect(homepage.hourly_active_users[time])
           .to contain_exactly('user1', 'user2', 'user3')
       end
     end
 
-    context 'with date and length' do
-      let(:date) { Time.local(2021, 4, 1, 11) }
+    context 'with time and length' do
+      let(:time) { Time.local(2021, 4, 1, 11) }
 
       it 'returns the members added within the duration' do
-        expect(homepage.hourly_active_users[date, 2])
+        expect(homepage.hourly_active_users[time, 2])
           .to contain_exactly('user1', 'user2', 'user3', 'user4', 'user5')
+      end
+    end
+
+    context 'with time and length (zero)' do
+      let(:time) { Time.local(2021, 4, 1, 11) }
+
+      it 'returns an empty array' do
+        expect(homepage.hourly_active_users[time, 0]).to eq []
       end
     end
 
@@ -107,31 +115,32 @@ RSpec.describe Redis::HourlySet do
   end
 
   describe '#delete_at' do
+    let(:time) { Time.local(2021, 4, 1, 11) }
+
     it 'deletes the members on the hour' do
-      date = Time.local(2021, 4, 1, 11)
-      expect { homepage.hourly_active_users.delete_at(date) }
-        .to change { homepage.hourly_active_users.at(date).length }
+      expect { homepage.hourly_active_users.delete_at(time) }
+        .to change { homepage.hourly_active_users.at(time).length }
         .from(4).to(0)
     end
   end
 
   describe '#range' do
-    let(:start_date) { Time.local(2021, 4, 1, 10) }
-    let(:end_date) { Time.local(2021, 4, 1, 11) }
+    let(:start_time) { Time.local(2021, 4, 1, 10) }
+    let(:end_time) { Time.local(2021, 4, 1, 11) }
 
     it 'returns the members added within the duration' do
-      expect(homepage.hourly_active_users.range(start_date, end_date))
+      expect(homepage.hourly_active_users.range(start_time, end_time))
         .to contain_exactly('user1', 'user2', 'user3', 'user4', 'user5')
     end
   end
 
   describe '#at' do
-    let(:date) { Time.local(2021, 4, 1, 11) }
+    let(:time) { Time.local(2021, 4, 1, 11) }
 
     it 'returns a set object added the hour' do
-      expect(homepage.hourly_active_users.at(date).members)
+      expect(homepage.hourly_active_users.at(time).members)
         .to contain_exactly('user1', 'user2', 'user4', 'user5')
-      expect(homepage.hourly_active_users.at(date).length)
+      expect(homepage.hourly_active_users.at(time).length)
         .to eq 4
     end
   end

--- a/spec/lib/redis/minutely_counter_spec.rb
+++ b/spec/lib/redis/minutely_counter_spec.rb
@@ -76,19 +76,27 @@ RSpec.describe Redis::MinutelyCounter do
   end
 
   describe '#[]' do
-    context 'with date' do
-      let(:date) { Time.local(2021, 4, 1, 10, 20) }
+    context 'with time' do
+      let(:time) { Time.local(2021, 4, 1, 10, 20) }
 
       it 'returns the value counted the minute' do
-        expect(homepage.pv[date]).to eq 10
+        expect(homepage.pv[time]).to eq 10
       end
     end
 
-    context 'with date and length' do
-      let(:date) { Time.local(2021, 4, 1, 10, 21) }
+    context 'with time and length' do
+      let(:time) { Time.local(2021, 4, 1, 10, 21) }
 
       it 'returns the values counted within the duration' do
-        expect(homepage.pv[date, 2]).to eq [11, 12]
+        expect(homepage.pv[time, 2]).to eq [11, 12]
+      end
+    end
+
+    context 'with time and length (zero)' do
+      let(:time) { Time.local(2021, 4, 1, 10, 21) }
+
+      it 'returns an empty array' do
+        expect(homepage.pv[time, 0]).to eq []
       end
     end
 
@@ -104,28 +112,29 @@ RSpec.describe Redis::MinutelyCounter do
   end
 
   describe '#delete_at' do
+    let(:time) { Time.local(2021, 4, 1, 10, 21) }
+
     it 'deletes the value on the minute' do
-      date = Time.local(2021, 4, 1, 10, 21)
-      expect { homepage.pv.delete_at(date) }
-        .to change { homepage.pv.at(date) }
+      expect { homepage.pv.delete_at(time) }
+        .to change { homepage.pv.at(time) }
         .from(11).to(0)
     end
   end
 
   describe '#range' do
-    let(:start_date) { Time.local(2021, 4, 1, 10, 20) }
-    let(:end_date) { Time.local(2021, 4, 1, 10, 21) }
+    let(:start_time) { Time.local(2021, 4, 1, 10, 20) }
+    let(:end_time) { Time.local(2021, 4, 1, 10, 21) }
 
     it 'returns the values counted within the duration' do
-      expect(homepage.pv.range(start_date, end_date)).to eq [10, 11]
+      expect(homepage.pv.range(start_time, end_time)).to eq [10, 11]
     end
   end
 
   describe '#at' do
-    let(:date) { Time.local(2021, 4, 1, 10, 21) }
+    let(:time) { Time.local(2021, 4, 1, 10, 21) }
 
     it 'returns a counter object counted the minute' do
-      expect(homepage.pv.at(date).value).to eq 11
+      expect(homepage.pv.at(time).value).to eq 11
     end
   end
 end

--- a/spec/lib/redis/minutely_hash_key_spec.rb
+++ b/spec/lib/redis/minutely_hash_key_spec.rb
@@ -83,19 +83,19 @@ RSpec.describe Redis::MinutelyHashKey do
   end
 
   describe '#[]' do
-    context 'with date' do
-      let(:date) { Time.local(2021, 4, 1, 10, 20) }
+    context 'with time' do
+      let(:time) { Time.local(2021, 4, 1, 10, 20) }
 
       it 'returns the field counted the year' do
-        expect(homepage.browsing_history[date]).to eq({ 'item1' => '1.5', 'item2' => '2' })
+        expect(homepage.browsing_history[time]).to eq({ 'item1' => '1.5', 'item2' => '2' })
       end
     end
 
-    context 'with date and length' do
-      let(:date) { Time.local(2021, 4, 1, 10, 21) }
+    context 'with time and length' do
+      let(:time) { Time.local(2021, 4, 1, 10, 21) }
 
       it 'returns the fields counted within the duration' do
-        expect(homepage.browsing_history[date, 2])
+        expect(homepage.browsing_history[time, 2])
           .to eq({ 'item1' => '3', 'item2' => 'a,1', 'item3' => '7', 'item4' => '1' })
       end
     end
@@ -113,29 +113,30 @@ RSpec.describe Redis::MinutelyHashKey do
   end
 
   describe '#delete_at' do
+    let(:time) { Time.local(2021, 4, 1, 10, 21) }
+
     it 'deletes the hash on the year' do
-      date = Time.local(2021, 4, 1, 10, 21)
-      expect { homepage.browsing_history.delete_at(date) }
-        .to change { homepage.browsing_history.at(date) }
+      expect { homepage.browsing_history.delete_at(time) }
+        .to change { homepage.browsing_history.at(time) }
         .from({ 'item1' => '3', 'item2' => 'a', 'item3' => '5' }).to({})
     end
   end
 
   describe '#range' do
-    let(:start_date) { Time.local(2021, 4, 1, 10, 20) }
-    let(:end_date) { Time.local(2021, 4, 1, 10, 21) }
+    let(:start_time) { Time.local(2021, 4, 1, 10, 20) }
+    let(:end_time) { Time.local(2021, 4, 1, 10, 21) }
 
     it 'returns the hash counted within the duration' do
-      expect(homepage.browsing_history.range(start_date, end_date))
+      expect(homepage.browsing_history.range(start_time, end_time))
         .to eq({ 'item1' => '4.5', 'item2' => '2,a', 'item3' => '5' })
     end
   end
 
   describe '#at' do
-    let(:date) { Time.local(2021, 4, 1, 10, 21) }
+    let(:time) { Time.local(2021, 4, 1, 10, 21) }
 
     it 'returns a counter object counted the year' do
-      expect(homepage.browsing_history.at(date).all)
+      expect(homepage.browsing_history.at(time).all)
         .to eq({ 'item1' => '3', 'item2' => 'a', 'item3' => '5' })
     end
   end

--- a/spec/lib/redis/minutely_set_spec.rb
+++ b/spec/lib/redis/minutely_set_spec.rb
@@ -76,21 +76,29 @@ RSpec.describe Redis::MinutelySet do
   end
 
   describe '#[]' do
-    context 'with date' do
-      let(:date) { Time.local(2021, 4, 1, 10, 20) }
+    context 'with time' do
+      let(:time) { Time.local(2021, 4, 1, 10, 20) }
 
       it 'returns the members added the minute' do
-        expect(homepage.minutely_active_users[date])
+        expect(homepage.minutely_active_users[time])
           .to contain_exactly('user1', 'user2', 'user3')
       end
     end
 
-    context 'with date and length' do
-      let(:date) { Time.local(2021, 4, 1, 10, 21) }
+    context 'with time and length' do
+      let(:time) { Time.local(2021, 4, 1, 10, 21) }
 
       it 'returns the members added within the duration' do
-        expect(homepage.minutely_active_users[date, 2])
+        expect(homepage.minutely_active_users[time, 2])
           .to contain_exactly('user1', 'user2', 'user3', 'user4', 'user5')
+      end
+    end
+
+    context 'with time and length (zero)' do
+      let(:time) { Time.local(2021, 4, 1, 10, 21) }
+
+      it 'returns an empty array' do
+        expect(homepage.minutely_active_users[time, 0]).to eq []
       end
     end
 
@@ -107,31 +115,32 @@ RSpec.describe Redis::MinutelySet do
   end
 
   describe '#delete_at' do
+    let(:time) { Time.local(2021, 4, 1, 10, 21) }
+
     it 'deletes the members on the minute' do
-      date = Time.local(2021, 4, 1, 10, 21)
-      expect { homepage.minutely_active_users.delete_at(date) }
-        .to change { homepage.minutely_active_users.at(date).length }
+      expect { homepage.minutely_active_users.delete_at(time) }
+        .to change { homepage.minutely_active_users.at(time).length }
         .from(4).to(0)
     end
   end
 
   describe '#range' do
-    let(:start_date) { Time.local(2021, 4, 1, 10, 20) }
-    let(:end_date) { Time.local(2021, 4, 1, 10, 21) }
+    let(:start_time) { Time.local(2021, 4, 1, 10, 20) }
+    let(:end_time) { Time.local(2021, 4, 1, 10, 21) }
 
     it 'returns the members added within the duration' do
-      expect(homepage.minutely_active_users.range(start_date, end_date))
+      expect(homepage.minutely_active_users.range(start_time, end_time))
         .to contain_exactly('user1', 'user2', 'user3', 'user4', 'user5')
     end
   end
 
   describe '#at' do
-    let(:date) { Time.local(2021, 4, 1, 10, 21) }
+    let(:time) { Time.local(2021, 4, 1, 10, 21) }
 
     it 'returns a set object added the minute' do
-      expect(homepage.minutely_active_users.at(date).members)
+      expect(homepage.minutely_active_users.at(time).members)
         .to contain_exactly('user1', 'user2', 'user4', 'user5')
-      expect(homepage.minutely_active_users.at(date).length)
+      expect(homepage.minutely_active_users.at(time).length)
         .to eq 4
     end
   end

--- a/spec/lib/redis/monthly_counter_spec.rb
+++ b/spec/lib/redis/monthly_counter_spec.rb
@@ -92,6 +92,14 @@ RSpec.describe Redis::MonthlyCounter do
       end
     end
 
+    context 'with date and length (zero)' do
+      let(:date) { Date.new(2021, 5, 1) }
+
+      it 'returns an empty array' do
+        expect(homepage.pv[date, 0]).to eq []
+      end
+    end
+
     context 'with range of date' do
       let(:range) do
         Date.new(2021, 4, 1)..Date.new(2021, 5, 1)
@@ -115,6 +123,14 @@ RSpec.describe Redis::MonthlyCounter do
 
       it 'returns the values counted within the duration' do
         expect(homepage.pv[time, 2]).to eq [11, 12]
+      end
+    end
+
+    context 'with time and length (zero)' do
+      let(:time) { Time.local(2021, 5, 1, 10, 20, 30) }
+
+      it 'returns an empty array' do
+        expect(homepage.pv[time, 0]).to eq []
       end
     end
 

--- a/spec/lib/redis/monthly_counter_spec.rb
+++ b/spec/lib/redis/monthly_counter_spec.rb
@@ -92,9 +92,35 @@ RSpec.describe Redis::MonthlyCounter do
       end
     end
 
-    context 'with range' do
+    context 'with range of date' do
       let(:range) do
         Date.new(2021, 4, 1)..Date.new(2021, 5, 1)
+      end
+
+      it 'returns the values counted within the duration' do
+        expect(homepage.pv[range]).to eq [10, 11]
+      end
+    end
+
+    context 'with time' do
+      let(:time) { Time.local(2021, 4, 1, 10, 20, 30) }
+
+      it 'returns the value counted the month' do
+        expect(homepage.pv[time]).to eq 10
+      end
+    end
+
+    context 'with time and length' do
+      let(:time) { Time.local(2021, 5, 1, 10, 20, 30) }
+
+      it 'returns the values counted within the duration' do
+        expect(homepage.pv[time, 2]).to eq [11, 12]
+      end
+    end
+
+    context 'with range of time' do
+      let(:range) do
+        Time.local(2021, 4, 1, 10, 20, 30)..Time.local(2021, 5, 1, 10, 20, 30)
       end
 
       it 'returns the values counted within the duration' do
@@ -104,28 +130,62 @@ RSpec.describe Redis::MonthlyCounter do
   end
 
   describe '#delete_at' do
-    it 'deletes the value on the month' do
-      date = Date.new(2021, 5, 1)
-      expect { homepage.pv.delete_at(date) }
-        .to change { homepage.pv.at(date) }
-        .from(11).to(0)
+    context 'with date' do
+      let(:date) { Date.new(2021, 5, 1) }
+
+      it 'deletes the value on the month' do
+        expect { homepage.pv.delete_at(date) }
+          .to change { homepage.pv.at(date) }
+          .from(11).to(0)
+      end
+    end
+
+    context 'with time' do
+      let(:time) { Time.local(2021, 5, 1, 10, 20, 30) }
+
+      it 'deletes the value on the month' do
+        expect { homepage.pv.delete_at(time) }
+          .to change { homepage.pv.at(time) }
+          .from(11).to(0)
+      end
     end
   end
 
   describe '#range' do
-    let(:start_date) { Date.new(2021, 4, 1) }
-    let(:end_date) { Date.new(2021, 5, 1) }
+    context 'with date' do
+      let(:start_date) { Date.new(2021, 4, 1) }
+      let(:end_date) { Date.new(2021, 5, 1) }
 
-    it 'returns the values counted within the duration' do
-      expect(homepage.pv.range(start_date, end_date)).to eq [10, 11]
+      it 'returns the values counted within the duration' do
+        expect(homepage.pv.range(start_date, end_date)).to eq [10, 11]
+      end
+    end
+
+    context 'with time' do
+      let(:start_time) { Time.local(2021, 4, 1, 10, 20, 30) }
+      let(:end_time) { Time.local(2021, 5, 1, 10, 20, 30) }
+
+      it 'returns the values counted within the duration' do
+        expect(homepage.pv.range(start_time, end_time)).to eq [10, 11]
+      end
     end
   end
 
   describe '#at' do
-    let(:date) { Date.new(2021, 5, 1) }
+    context 'with date' do
+      let(:date) { Date.new(2021, 5, 1) }
 
-    it 'returns a counter object counted the month' do
-      expect(homepage.pv.at(date).value).to eq 11
+      it 'returns a counter object counted the month' do
+        expect(homepage.pv.at(date).value).to eq 11
+      end
+    end
+
+    context 'with time' do
+      let(:time) { Time.local(2021, 5, 1, 10, 20, 30) }
+
+      it 'returns a counter object counted the month' do
+        expect(homepage.pv.at(time).value).to eq 11
+      end
     end
   end
 end

--- a/spec/lib/redis/monthly_hash_key_spec.rb
+++ b/spec/lib/redis/monthly_hash_key_spec.rb
@@ -100,6 +100,14 @@ RSpec.describe Redis::MonthlyHashKey do
       end
     end
 
+    context 'with date and length (zero)' do
+      let(:date) { Date.new(2021, 5, 1) }
+
+      it 'returns an empty hash' do
+        expect(homepage.browsing_history[date, 0]).to eq({})
+      end
+    end
+
     context 'with range of date' do
       let(:range) do
         Date.new(2021, 4, 1)..Date.new(2021, 5, 1)
@@ -125,6 +133,14 @@ RSpec.describe Redis::MonthlyHashKey do
       it 'returns the fields counted within the duration' do
         expect(homepage.browsing_history[time, 2])
           .to eq({ 'item1' => '3', 'item2' => 'a,1', 'item3' => '7', 'item4' => '1' })
+      end
+    end
+
+    context 'with time and length (zero)' do
+      let(:time) { Time.local(2021, 5, 1, 10, 20, 30) }
+
+      it 'returns an empty hash' do
+        expect(homepage.browsing_history[time, 0]).to eq({})
       end
     end
 

--- a/spec/lib/redis/monthly_hash_key_spec.rb
+++ b/spec/lib/redis/monthly_hash_key_spec.rb
@@ -100,9 +100,37 @@ RSpec.describe Redis::MonthlyHashKey do
       end
     end
 
-    context 'with range' do
+    context 'with range of date' do
       let(:range) do
         Date.new(2021, 4, 1)..Date.new(2021, 5, 1)
+      end
+
+      it 'returns the values counted within the duration' do
+        expect(homepage.browsing_history[range])
+          .to eq({ 'item1' => '4.5', 'item2' => '2,a', 'item3' => '5' })
+      end
+    end
+
+    context 'with time' do
+      let(:time) { Time.local(2021, 4, 1, 10, 20, 30) }
+
+      it 'returns the field counted the year' do
+        expect(homepage.browsing_history[time]).to eq({ 'item1' => '1.5', 'item2' => '2' })
+      end
+    end
+
+    context 'with time and length' do
+      let(:time) { Time.local(2021, 5, 1, 10, 20, 30) }
+
+      it 'returns the fields counted within the duration' do
+        expect(homepage.browsing_history[time, 2])
+          .to eq({ 'item1' => '3', 'item2' => 'a,1', 'item3' => '7', 'item4' => '1' })
+      end
+    end
+
+    context 'with range of time' do
+      let(:range) do
+        Time.local(2021, 4, 1, 10, 20, 30)..Time.local(2021, 5, 1, 10, 20, 30)
       end
 
       it 'returns the values counted within the duration' do
@@ -113,30 +141,66 @@ RSpec.describe Redis::MonthlyHashKey do
   end
 
   describe '#delete_at' do
-    it 'deletes the hash on the year' do
-      date = Date.new(2021, 5, 1)
-      expect { homepage.browsing_history.delete_at(date) }
-        .to change { homepage.browsing_history.at(date) }
-        .from({ 'item1' => '3', 'item2' => 'a', 'item3' => '5' }).to({})
+    context 'with date' do
+      let(:date) { Date.new(2021, 5, 1) }
+
+      it 'deletes the hash on the year' do
+        expect { homepage.browsing_history.delete_at(date) }
+          .to change { homepage.browsing_history.at(date) }
+          .from({ 'item1' => '3', 'item2' => 'a', 'item3' => '5' }).to({})
+      end
+    end
+
+    context 'with time' do
+      let(:time) { Time.local(2021, 5, 1, 10, 20, 30) }
+
+      it 'deletes the hash on the year' do
+        expect { homepage.browsing_history.delete_at(time) }
+          .to change { homepage.browsing_history.at(time) }
+          .from({ 'item1' => '3', 'item2' => 'a', 'item3' => '5' }).to({})
+      end
     end
   end
 
   describe '#range' do
-    let(:start_date) { Date.new(2021, 4, 1) }
-    let(:end_date) { Date.new(2021, 5, 1) }
+    context 'with date' do
+      let(:start_date) { Date.new(2021, 4, 1) }
+      let(:end_date) { Date.new(2021, 5, 1) }
 
-    it 'returns the hash counted within the duration' do
-      expect(homepage.browsing_history.range(start_date, end_date))
-        .to eq({ 'item1' => '4.5', 'item2' => '2,a', 'item3' => '5' })
+      it 'returns the hash counted within the duration' do
+        expect(homepage.browsing_history.range(start_date, end_date))
+          .to eq({ 'item1' => '4.5', 'item2' => '2,a', 'item3' => '5' })
+      end
+    end
+
+    context 'with time' do
+      let(:start_time) { Time.local(2021, 4, 1, 10, 20, 30) }
+      let(:end_time) { Time.local(2021, 5, 1, 10, 20, 30) }
+
+      it 'returns the hash counted within the duration' do
+        expect(homepage.browsing_history.range(start_time, end_time))
+          .to eq({ 'item1' => '4.5', 'item2' => '2,a', 'item3' => '5' })
+      end
     end
   end
 
   describe '#at' do
-    let(:date) { Date.new(2021, 5, 1) }
+    context 'with date' do
+      let(:date) { Date.new(2021, 5, 1) }
 
-    it 'returns a counter object counted the year' do
-      expect(homepage.browsing_history.at(date).all)
-        .to eq({ 'item1' => '3', 'item2' => 'a', 'item3' => '5' })
+      it 'returns a counter object counted the year' do
+        expect(homepage.browsing_history.at(date).all)
+          .to eq({ 'item1' => '3', 'item2' => 'a', 'item3' => '5' })
+      end
+    end
+
+    context 'with time' do
+      let(:time) { Time.local(2021, 5, 1, 10, 20, 30) }
+
+      it 'returns a counter object counted the year' do
+        expect(homepage.browsing_history.at(time).all)
+          .to eq({ 'item1' => '3', 'item2' => 'a', 'item3' => '5' })
+      end
     end
   end
 end

--- a/spec/lib/redis/monthly_set_spec.rb
+++ b/spec/lib/redis/monthly_set_spec.rb
@@ -94,6 +94,14 @@ RSpec.describe Redis::MonthlySet do
       end
     end
 
+    context 'with date and length (zero)' do
+      let(:date) { Date.new(2021, 5, 1) }
+
+      it 'returns an empty array' do
+        expect(homepage.monthly_active_users[date, 0]).to eq []
+      end
+    end
+
     context 'with range of date' do
       let(:range) do
         Date.new(2021, 4, 1)..Date.new(2021, 5, 1)
@@ -120,6 +128,14 @@ RSpec.describe Redis::MonthlySet do
       it 'returns the members added within the duration' do
         expect(homepage.monthly_active_users[time, 2])
           .to contain_exactly('user1', 'user2', 'user3', 'user4', 'user5')
+      end
+    end
+
+    context 'with time and length (zero)' do
+      let(:time) { Time.local(2021, 5, 1, 10, 20, 30) }
+
+      it 'returns an empty array' do
+        expect(homepage.monthly_active_users[time, 0]).to eq []
       end
     end
 

--- a/spec/lib/redis/monthly_set_spec.rb
+++ b/spec/lib/redis/monthly_set_spec.rb
@@ -94,9 +94,38 @@ RSpec.describe Redis::MonthlySet do
       end
     end
 
-    context 'with range' do
+    context 'with range of date' do
       let(:range) do
         Date.new(2021, 4, 1)..Date.new(2021, 5, 1)
+      end
+
+      it 'returns the members counted within the duration' do
+        expect(homepage.monthly_active_users[range])
+          .to contain_exactly('user1', 'user2', 'user3', 'user4', 'user5')
+      end
+    end
+
+    context 'with time' do
+      let(:time) { Time.local(2021, 4, 1, 10, 20, 30) }
+
+      it 'returns the members added the month' do
+        expect(homepage.monthly_active_users[time])
+          .to contain_exactly('user1', 'user2', 'user3')
+      end
+    end
+
+    context 'with time and length' do
+      let(:time) { Time.local(2021, 5, 1, 10, 20, 30) }
+
+      it 'returns the members added within the duration' do
+        expect(homepage.monthly_active_users[time, 2])
+          .to contain_exactly('user1', 'user2', 'user3', 'user4', 'user5')
+      end
+    end
+
+    context 'with range of time' do
+      let(:range) do
+        Time.local(2021, 4, 1, 10, 20, 30)..Time.local(2021, 5, 1, 10, 20, 30)
       end
 
       it 'returns the members counted within the duration' do
@@ -107,32 +136,70 @@ RSpec.describe Redis::MonthlySet do
   end
 
   describe '#delete_at' do
-    it 'deletes the members on the month' do
-      date = Date.new(2021, 5, 1)
-      expect { homepage.monthly_active_users.delete_at(date) }
-        .to change { homepage.monthly_active_users.at(date).length }
-        .from(4).to(0)
+    context 'with date' do
+      let(:date) { Date.new(2021, 5, 1) }
+
+      it 'deletes the members on the month' do
+        expect { homepage.monthly_active_users.delete_at(date) }
+          .to change { homepage.monthly_active_users.at(date).length }
+          .from(4).to(0)
+      end
+    end
+
+    context 'with time' do
+      let(:time) { Time.local(2021, 5, 1, 10, 20, 30) }
+
+      it 'deletes the members on the month' do
+        expect { homepage.monthly_active_users.delete_at(time) }
+          .to change { homepage.monthly_active_users.at(time).length }
+          .from(4).to(0)
+      end
     end
   end
 
   describe '#range' do
-    let(:start_date) { Date.new(2021, 4, 1) }
-    let(:end_date) { Date.new(2021, 5, 1) }
+    context 'with date' do
+      let(:start_date) { Date.new(2021, 4, 1) }
+      let(:end_date) { Date.new(2021, 5, 1) }
 
-    it 'returns the members added within the duration' do
-      expect(homepage.monthly_active_users.range(start_date, end_date))
-        .to contain_exactly('user1', 'user2', 'user3', 'user4', 'user5')
+      it 'returns the members added within the duration' do
+        expect(homepage.monthly_active_users.range(start_date, end_date))
+          .to contain_exactly('user1', 'user2', 'user3', 'user4', 'user5')
+      end
+    end
+
+    context 'with time' do
+      let(:start_time) { Time.local(2021, 4, 1, 10, 20, 30) }
+      let(:end_time) { Time.local(2021, 5, 1, 10, 20, 30) }
+
+      it 'returns the members added within the duration' do
+        expect(homepage.monthly_active_users.range(start_time, end_time))
+          .to contain_exactly('user1', 'user2', 'user3', 'user4', 'user5')
+      end
     end
   end
 
   describe '#at' do
-    let(:date) { Date.new(2021, 5, 1) }
+    context 'with date' do
+      let(:date) { Date.new(2021, 5, 1) }
 
-    it 'returns a set object added the month' do
-      expect(homepage.monthly_active_users.at(date).members)
-        .to contain_exactly('user1', 'user2', 'user4', 'user5')
-      expect(homepage.monthly_active_users.at(date).length)
-        .to eq 4
+      it 'returns a set object added the month' do
+        expect(homepage.monthly_active_users.at(date).members)
+          .to contain_exactly('user1', 'user2', 'user4', 'user5')
+        expect(homepage.monthly_active_users.at(date).length)
+          .to eq 4
+      end
+    end
+
+    context 'with time' do
+      let(:time) { Time.local(2021, 5, 1, 10, 20, 30) }
+
+      it 'returns a set object added the month' do
+        expect(homepage.monthly_active_users.at(time).members)
+          .to contain_exactly('user1', 'user2', 'user4', 'user5')
+        expect(homepage.monthly_active_users.at(time).length)
+          .to eq 4
+      end
     end
   end
 end

--- a/spec/lib/redis/weekly_counter_spec.rb
+++ b/spec/lib/redis/weekly_counter_spec.rb
@@ -92,6 +92,14 @@ RSpec.describe Redis::WeeklyCounter do
       end
     end
 
+    context 'with date and length (zero)' do
+      let(:date) { Date.new(2022, 4, 1) }
+
+      it 'returns an empty array' do
+        expect(homepage.pv[date, 0]).to eq []
+      end
+    end
+
     context 'with range of date' do
       let(:range) do
         Date.new(2021, 4, 1)..Date.new(2021, 4, 8)
@@ -115,6 +123,14 @@ RSpec.describe Redis::WeeklyCounter do
 
       it 'returns the values counted within the duration' do
         expect(homepage.pv[time, 2]).to eq [11, 12]
+      end
+    end
+
+    context 'with time and length (zero)' do
+      let(:time) { Time.local(2022, 4, 1, 10, 20, 30) }
+
+      it 'returns an empty array' do
+        expect(homepage.pv[time, 0]).to eq []
       end
     end
 

--- a/spec/lib/redis/weekly_counter_spec.rb
+++ b/spec/lib/redis/weekly_counter_spec.rb
@@ -92,9 +92,35 @@ RSpec.describe Redis::WeeklyCounter do
       end
     end
 
-    context 'with range' do
+    context 'with range of date' do
       let(:range) do
         Date.new(2021, 4, 1)..Date.new(2021, 4, 8)
+      end
+
+      it 'returns the values counted within the duration' do
+        expect(homepage.pv[range]).to eq [10, 11]
+      end
+    end
+
+    context 'with time' do
+      let(:time) { Time.local(2021, 4, 1, 10, 20, 30) }
+
+      it 'returns the value counted the week' do
+        expect(homepage.pv[time]).to eq 10
+      end
+    end
+
+    context 'with time and length' do
+      let(:time) { Time.local(2021, 4, 8, 10, 20, 30) }
+
+      it 'returns the values counted within the duration' do
+        expect(homepage.pv[time, 2]).to eq [11, 12]
+      end
+    end
+
+    context 'with range of time' do
+      let(:range) do
+        Time.local(2021, 4, 1, 10, 20, 30)..Time.local(2021, 4, 8, 10, 20, 30)
       end
 
       it 'returns the values counted within the duration' do
@@ -104,28 +130,62 @@ RSpec.describe Redis::WeeklyCounter do
   end
 
   describe '#delete_at' do
-    it 'deletes the value on the week' do
-      date = Date.new(2021, 4, 8)
-      expect { homepage.pv.delete_at(date) }
-        .to change { homepage.pv.at(date) }
-        .from(11).to(0)
+    context 'with date' do
+      let(:date) { Date.new(2021, 4, 8) }
+
+      it 'deletes the value on the week' do
+        expect { homepage.pv.delete_at(date) }
+          .to change { homepage.pv.at(date) }
+          .from(11).to(0)
+      end
+    end
+
+    context 'with time' do
+      let(:time) { Time.local(2021, 4, 8, 10, 20, 30) }
+
+      it 'deletes the value on the week' do
+        expect { homepage.pv.delete_at(time) }
+          .to change { homepage.pv.at(time) }
+          .from(11).to(0)
+      end
     end
   end
 
   describe '#range' do
-    let(:start_date) { Date.new(2021, 4, 1) }
-    let(:end_date) { Date.new(2021, 4, 8) }
+    context 'with date' do
+      let(:start_date) { Date.new(2021, 4, 1) }
+      let(:end_date) { Date.new(2021, 4, 8) }
 
-    it 'returns the values counted within the duration' do
-      expect(homepage.pv.range(start_date, end_date)).to eq [10, 11]
+      it 'returns the values counted within the duration' do
+        expect(homepage.pv.range(start_date, end_date)).to eq [10, 11]
+      end
+    end
+
+    context 'with time' do
+      let(:start_time) { Time.local(2021, 4, 1, 10, 20, 30) }
+      let(:end_time) { Time.local(2021, 4, 8, 10, 20, 30) }
+
+      it 'returns the values counted within the duration' do
+        expect(homepage.pv.range(start_time, end_time)).to eq [10, 11]
+      end
     end
   end
 
   describe '#at' do
-    let(:date) { Date.new(2021, 4, 8) }
+    context 'with date' do
+      let(:date) { Date.new(2021, 4, 8) }
 
-    it 'returns a counter object counted the week' do
-      expect(homepage.pv.at(date).value).to eq 11
+      it 'returns a counter object counted the week' do
+        expect(homepage.pv.at(date).value).to eq 11
+      end
+    end
+
+    context 'with time' do
+      let(:time) { Time.local(2021, 4, 8, 10, 20, 30) }
+
+      it 'returns a counter object counted the week' do
+        expect(homepage.pv.at(time).value).to eq 11
+      end
     end
   end
 end

--- a/spec/lib/redis/weekly_hash_key_spec.rb
+++ b/spec/lib/redis/weekly_hash_key_spec.rb
@@ -100,9 +100,37 @@ RSpec.describe Redis::WeeklyHashKey do
       end
     end
 
-    context 'with range' do
+    context 'with range of date' do
       let(:range) do
         Date.new(2021, 4, 1)..Date.new(2021, 4, 8)
+      end
+
+      it 'returns the values counted within the duration' do
+        expect(homepage.browsing_history[range])
+          .to eq({ 'item1' => '4.5', 'item2' => '2,a', 'item3' => '5' })
+      end
+    end
+
+    context 'with time' do
+      let(:time) { Time.local(2021, 4, 1, 10, 20, 30) }
+
+      it 'returns the field counted the year' do
+        expect(homepage.browsing_history[time]).to eq({ 'item1' => '1.5', 'item2' => '2' })
+      end
+    end
+
+    context 'with time and length' do
+      let(:time) { Time.local(2021, 4, 8, 10, 20, 30) }
+
+      it 'returns the fields counted within the duration' do
+        expect(homepage.browsing_history[time, 2])
+          .to eq({ 'item1' => '3', 'item2' => 'a,1', 'item3' => '7', 'item4' => '1' })
+      end
+    end
+
+    context 'with range of time' do
+      let(:range) do
+        Time.local(2021, 4, 1, 10, 20, 30)..Time.local(2021, 4, 8, 10, 20, 30)
       end
 
       it 'returns the values counted within the duration' do
@@ -113,30 +141,66 @@ RSpec.describe Redis::WeeklyHashKey do
   end
 
   describe '#delete_at' do
-    it 'deletes the hash on the year' do
-      date = Date.new(2021, 4, 8)
-      expect { homepage.browsing_history.delete_at(date) }
-        .to change { homepage.browsing_history.at(date) }
-        .from({ 'item1' => '3', 'item2' => 'a', 'item3' => '5' }).to({})
+    context 'with date' do
+      let(:date) { Date.new(2021, 4, 8) }
+
+      it 'deletes the hash on the year' do
+        expect { homepage.browsing_history.delete_at(date) }
+          .to change { homepage.browsing_history.at(date) }
+          .from({ 'item1' => '3', 'item2' => 'a', 'item3' => '5' }).to({})
+      end
+    end
+
+    context 'with time' do
+      let(:time) { Time.local(2021, 4, 8) }
+
+      it 'deletes the hash on the year' do
+        expect { homepage.browsing_history.delete_at(time) }
+          .to change { homepage.browsing_history.at(time) }
+          .from({ 'item1' => '3', 'item2' => 'a', 'item3' => '5' }).to({})
+      end
     end
   end
 
   describe '#range' do
-    let(:start_date) { Date.new(2021, 4, 1) }
-    let(:end_date) { Date.new(2021, 4, 8) }
+    context 'with date' do
+      let(:start_date) { Date.new(2021, 4, 1) }
+      let(:end_date) { Date.new(2021, 4, 8) }
 
-    it 'returns the hash counted within the duration' do
-      expect(homepage.browsing_history.range(start_date, end_date))
-        .to eq({ 'item1' => '4.5', 'item2' => '2,a', 'item3' => '5' })
+      it 'returns the hash counted within the duration' do
+        expect(homepage.browsing_history.range(start_date, end_date))
+          .to eq({ 'item1' => '4.5', 'item2' => '2,a', 'item3' => '5' })
+      end
+    end
+
+    context 'with time' do
+      let(:start_time) { Time.local(2021, 4, 1) }
+      let(:end_time) { Time.local(2021, 4, 8) }
+
+      it 'returns the hash counted within the duration' do
+        expect(homepage.browsing_history.range(start_time, end_time))
+          .to eq({ 'item1' => '4.5', 'item2' => '2,a', 'item3' => '5' })
+      end
     end
   end
 
   describe '#at' do
-    let(:date) { Date.new(2021, 4, 8) }
+    context 'with date' do
+      let(:date) { Date.new(2021, 4, 8) }
 
-    it 'returns a counter object counted the year' do
-      expect(homepage.browsing_history.at(date).all)
-        .to eq({ 'item1' => '3', 'item2' => 'a', 'item3' => '5' })
+      it 'returns a counter object counted the year' do
+        expect(homepage.browsing_history.at(date).all)
+          .to eq({ 'item1' => '3', 'item2' => 'a', 'item3' => '5' })
+      end
+    end
+
+    context 'with time' do
+      let(:time) { Time.local(2021, 4, 8) }
+
+      it 'returns a counter object counted the year' do
+        expect(homepage.browsing_history.at(time).all)
+          .to eq({ 'item1' => '3', 'item2' => 'a', 'item3' => '5' })
+      end
     end
   end
 end

--- a/spec/lib/redis/weekly_hash_key_spec.rb
+++ b/spec/lib/redis/weekly_hash_key_spec.rb
@@ -100,6 +100,14 @@ RSpec.describe Redis::WeeklyHashKey do
       end
     end
 
+    context 'with date and length (zero)' do
+      let(:date) { Date.new(2021, 4, 8) }
+
+      it 'returns an empty hash' do
+        expect(homepage.browsing_history[date, 0]).to eq({})
+      end
+    end
+
     context 'with range of date' do
       let(:range) do
         Date.new(2021, 4, 1)..Date.new(2021, 4, 8)
@@ -125,6 +133,14 @@ RSpec.describe Redis::WeeklyHashKey do
       it 'returns the fields counted within the duration' do
         expect(homepage.browsing_history[time, 2])
           .to eq({ 'item1' => '3', 'item2' => 'a,1', 'item3' => '7', 'item4' => '1' })
+      end
+    end
+
+    context 'with time and length (zero)' do
+      let(:time) { Time.local(2021, 4, 8, 10, 20, 30) }
+
+      it 'returns an empty hash' do
+        expect(homepage.browsing_history[time, 0]).to eq({})
       end
     end
 

--- a/spec/lib/redis/weekly_set_spec.rb
+++ b/spec/lib/redis/weekly_set_spec.rb
@@ -94,9 +94,38 @@ RSpec.describe Redis::WeeklySet do
       end
     end
 
-    context 'with range' do
+    context 'with range of date' do
       let(:range) do
         Date.new(2021, 4, 1)..Date.new(2021, 4, 8)
+      end
+
+      it 'returns the members counted within the duration' do
+        expect(homepage.weekly_active_users[range])
+          .to contain_exactly('user1', 'user2', 'user3', 'user4', 'user5')
+      end
+    end
+
+    context 'with time' do
+      let(:time) { Time.local(2021, 4, 1, 10, 20, 30) }
+
+      it 'returns the members added the week' do
+        expect(homepage.weekly_active_users[time])
+          .to contain_exactly('user1', 'user2', 'user3')
+      end
+    end
+
+    context 'with time and length' do
+      let(:time) { Time.local(2021, 4, 8, 10, 20, 30) }
+
+      it 'returns the members added within the duration' do
+        expect(homepage.weekly_active_users[time, 2])
+          .to contain_exactly('user1', 'user2', 'user3', 'user4', 'user5')
+      end
+    end
+
+    context 'with range of time' do
+      let(:range) do
+        Time.local(2021, 4, 1, 10, 20, 30)..Time.local(2021, 4, 8, 10, 20, 30)
       end
 
       it 'returns the members counted within the duration' do
@@ -107,32 +136,70 @@ RSpec.describe Redis::WeeklySet do
   end
 
   describe '#delete_at' do
-    it 'deletes the members on the week' do
-      date = Date.new(2021, 4, 8)
-      expect { homepage.weekly_active_users.delete_at(date) }
-        .to change { homepage.weekly_active_users.at(date).length }
-        .from(4).to(0)
+    context 'with date' do
+      let(:date) { Date.new(2021, 4, 8) }
+
+      it 'deletes the members on the week' do
+        expect { homepage.weekly_active_users.delete_at(date) }
+          .to change { homepage.weekly_active_users.at(date).length }
+          .from(4).to(0)
+      end
+    end
+
+    context 'with time' do
+      let(:time) { Time.local(2021, 4, 8, 10, 20, 30) }
+
+      it 'deletes the members on the week' do
+        expect { homepage.weekly_active_users.delete_at(time) }
+          .to change { homepage.weekly_active_users.at(time).length }
+          .from(4).to(0)
+      end
     end
   end
 
   describe '#range' do
-    let(:start_date) { Date.new(2021, 4, 1) }
-    let(:end_date) { Date.new(2021, 4, 8) }
+    context 'with date' do
+      let(:start_date) { Date.new(2021, 4, 1) }
+      let(:end_date) { Date.new(2021, 4, 8) }
 
-    it 'returns the members added within the duration' do
-      expect(homepage.weekly_active_users.range(start_date, end_date))
-        .to contain_exactly('user1', 'user2', 'user3', 'user4', 'user5')
+      it 'returns the members added within the duration' do
+        expect(homepage.weekly_active_users.range(start_date, end_date))
+          .to contain_exactly('user1', 'user2', 'user3', 'user4', 'user5')
+      end
+    end
+
+    context 'with time' do
+      let(:start_time) { Time.local(2021, 4, 1, 10, 20, 30) }
+      let(:end_time) { Time.local(2021, 4, 8, 10, 20, 30) }
+
+      it 'returns the members added within the duration' do
+        expect(homepage.weekly_active_users.range(start_time, end_time))
+          .to contain_exactly('user1', 'user2', 'user3', 'user4', 'user5')
+      end
     end
   end
 
   describe '#at' do
-    let(:date) { Date.new(2021, 4, 8) }
+    context 'with date' do
+      let(:date) { Date.new(2021, 4, 8) }
 
-    it 'returns a set object added the week' do
-      expect(homepage.weekly_active_users.at(date).members)
-        .to contain_exactly('user1', 'user2', 'user4', 'user5')
-      expect(homepage.weekly_active_users.at(date).length)
-        .to eq 4
+      it 'returns a set object added the week' do
+        expect(homepage.weekly_active_users.at(date).members)
+          .to contain_exactly('user1', 'user2', 'user4', 'user5')
+        expect(homepage.weekly_active_users.at(date).length)
+          .to eq 4
+      end
+    end
+
+    context 'with time' do
+      let(:time) { Time.local(2021, 4, 8, 10, 20, 30) }
+
+      it 'returns a set object added the week' do
+        expect(homepage.weekly_active_users.at(time).members)
+          .to contain_exactly('user1', 'user2', 'user4', 'user5')
+        expect(homepage.weekly_active_users.at(time).length)
+          .to eq 4
+      end
     end
   end
 end

--- a/spec/lib/redis/weekly_set_spec.rb
+++ b/spec/lib/redis/weekly_set_spec.rb
@@ -94,6 +94,14 @@ RSpec.describe Redis::WeeklySet do
       end
     end
 
+    context 'with date and length (zero)' do
+      let(:date) { Date.new(2021, 4, 8) }
+
+      it 'returns an empty array' do
+        expect(homepage.weekly_active_users[date, 0]).to eq []
+      end
+    end
+
     context 'with range of date' do
       let(:range) do
         Date.new(2021, 4, 1)..Date.new(2021, 4, 8)
@@ -120,6 +128,14 @@ RSpec.describe Redis::WeeklySet do
       it 'returns the members added within the duration' do
         expect(homepage.weekly_active_users[time, 2])
           .to contain_exactly('user1', 'user2', 'user3', 'user4', 'user5')
+      end
+    end
+
+    context 'with time and length (zero)' do
+      let(:time) { Time.local(2021, 4, 8, 10, 20, 30) }
+
+      it 'returns an empty array' do
+        expect(homepage.weekly_active_users[time, 0]).to eq []
       end
     end
 


### PR DESCRIPTION
This PR enhances casting from `Time` to `Date`.

## Before

```rb
homepage = Homepage.new
homepage.daily_active_users[Date.new(2021, 4, 1)] # OK
homepage.daily_active_users[Time.local(2021, 4, 1, 0, 0, 0)] # Error!
```

## After

```rb
homepage = Homepage.new
homepage.daily_active_users[Date.new(2021, 4, 1)] # OK
homepage.daily_active_users[Time.local(2021, 4, 1, 0, 0, 0)] # OK
```