### PR TITLE
Periodical::Value

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -10,16 +10,17 @@
 # Configuration parameters: AllowedConstants.
 Style/Documentation:
   Exclude:
-    - 'spec/**/*'
-    - 'test/**/*'
-    - 'lib/redis-objects-periodical.rb'
-    - 'lib/redis/base_counter_object.rb'
-    - 'lib/redis/base_hash_key_object.rb'
-    - 'lib/redis/base_set_object.rb'
-    - 'lib/redis/recurring_at_intervals.rb'
-    - 'lib/redis/recurring_at_intervals/annual.rb'
-    - 'lib/redis/recurring_at_intervals/daily.rb'
-    - 'lib/redis/recurring_at_intervals/hourly.rb'
-    - 'lib/redis/recurring_at_intervals/minutely.rb'
-    - 'lib/redis/recurring_at_intervals/monthly.rb'
-    - 'lib/redis/recurring_at_intervals/weekly.rb'
+    - "spec/**/*"
+    - "test/**/*"
+    - "lib/redis-objects-periodical.rb"
+    - "lib/redis/base_counter_object.rb"
+    - "lib/redis/base_hash_key_object.rb"
+    - "lib/redis/base_set_object.rb"
+    - "lib/redis/base_value_object.rb"
+    - "lib/redis/recurring_at_intervals.rb"
+    - "lib/redis/recurring_at_intervals/annual.rb"
+    - "lib/redis/recurring_at_intervals/daily.rb"
+    - "lib/redis/recurring_at_intervals/hourly.rb"
+    - "lib/redis/recurring_at_intervals/minutely.rb"
+    - "lib/redis/recurring_at_intervals/monthly.rb"
+    - "lib/redis/recurring_at_intervals/weekly.rb"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     redis-objects-periodical (0.6.0)
-      redis-objects
+      redis-objects (~> 1.0)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ class Homepage
   daily_counter :pv, expireat: -> { Time.now + 2_678_400 } # about a month
   daily_hash_key :browsing_history, expireat: -> { Time.now + 2_678_400 } # about a month
   daily_set :dau, expireat: -> { Time.now + 2_678_400 } # about a month
+  daily_value :cache, expireat: -> { Time.now + 2_678_400 } # about a month
 
   def id
     1
@@ -97,6 +98,46 @@ homepage.pv.at(Date.new(2021, 4, 2)).value # 2
 - `hourly_counter`
   - Key format: `model_name:id:field_name:yyyy-mm-ddThh`
 - `minutely_counter`
+  - Key format: `model_name:id:field_name:yyyy-mm-ddThh:mi`
+
+### Periodical Values
+
+The periodical values automatically switches the save destination when the date changes.
+
+```rb
+# 2021-04-01
+homepage.cache.value = 'a'
+
+# 2021-04-02 (next day)
+homepage.cache.value = 'b'
+
+# 2021-04-03 (next day)
+homepage.cache.value = 'c'
+
+homepage.cache[Date.new(2021, 4, 1)] # => 'a'
+homepage.cache[Date.new(2021, 4, 1), 3] # => ['a', 'b', 'c']
+homepage.cache[Date.new(2021, 4, 1)..Date.new(2021, 4, 2)] # => ['a', 'b']
+
+homepage.cache.delete_at(Date.new(2021, 4, 1))
+homepage.cache.range(Date.new(2021, 4, 1), Date.new(2021, 4, 3)) # => [nil, 'b', 'c']
+homepage.cache.at(Date.new(2021, 4, 2)) # => #<Redis::Value key="homepage:1:cache:2021-04-02">
+homepage.cache.at(Date.new(2021, 4, 2)).value # 'b'
+```
+
+#### Periodical Values Family
+
+- `annual_value`
+  - Key format: `model_name:id:field_name:yyyy`
+  - Redis is a highly volatile key-value store, so I don't recommend using it.
+- `monthly_value`
+  - Key format: `model_name:id:field_name:yyyy-mm`
+- `weekly_value`
+  - Key format: `model_name:id:field_name:yyyyWw`
+- `daily_value`
+  - Key format: `model_name:id:field_name:yyyy-mm-dd`
+- `hourly_value`
+  - Key format: `model_name:id:field_name:yyyy-mm-ddThh`
+- `minutely_value`
   - Key format: `model_name:id:field_name:yyyy-mm-ddThh:mi`
 
 ### Periodical Hashes

--- a/lib/redis-objects-periodical.rb
+++ b/lib/redis-objects-periodical.rb
@@ -9,6 +9,7 @@ class Redis
     autoload :"#{periodical.capitalize}Counter", 'redis/periodical_counter'
     autoload :"#{periodical.capitalize}HashKey", 'redis/periodical_hash_key'
     autoload :"#{periodical.capitalize}Set", 'redis/periodical_set'
+    autoload :"#{periodical.capitalize}Value", 'redis/periodical_value'
   end
 
   module Objects
@@ -16,6 +17,7 @@ class Redis
       autoload :"#{periodical.capitalize}Counters", 'redis/objects/periodical_counters'
       autoload :"#{periodical.capitalize}Hashes", 'redis/objects/periodical_hashes'
       autoload :"#{periodical.capitalize}Sets", 'redis/objects/periodical_sets'
+      autoload :"#{periodical.capitalize}Values", 'redis/objects/periodical_values'
     end
 
     class << self
@@ -29,6 +31,7 @@ class Redis
           klass.send :include, const_get("Redis::Objects::#{periodical.capitalize}Counters")
           klass.send :include, const_get("Redis::Objects::#{periodical.capitalize}Hashes")
           klass.send :include, const_get("Redis::Objects::#{periodical.capitalize}Sets")
+          klass.send :include, const_get("Redis::Objects::#{periodical.capitalize}Values")
         end
       end
     end

--- a/lib/redis/base_value_object.rb
+++ b/lib/redis/base_value_object.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class Redis
+  module BaseValueObject
+    private
+
+    def get_redis_object(key)
+      Redis::Value.new(key)
+    end
+
+    def get_value_from_redis(key)
+      unmarshal(redis.get(key))
+    end
+
+    def get_values_from_redis(keys)
+      redis.mget(*keys).map { |v| unmarshal(v) }
+    end
+
+    def delete_from_redis(key)
+      redis.del(key)
+    end
+
+    def empty_value
+      []
+    end
+  end
+end

--- a/lib/redis/objects/periodical_values.rb
+++ b/lib/redis/objects/periodical_values.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'redis/periodical_value'
+
+Redis::PERIODICALS.each do |periodical| # rubocop:disable Metrics/BlockLength
+  new_module = Module.new
+  new_module.module_eval <<~RUBY, __FILE__, __LINE__ + 1
+    def self.included(klass)
+      klass.extend ClassMethods
+    end
+
+    module ClassMethods
+      def #{periodical}_value(name, options = {})
+        redis_objects[name.to_sym] = options.merge(:type => :value)
+
+        mod = Module.new do
+          define_method(name) do
+            Redis::#{periodical.capitalize}Value.new(
+              redis_field_key(name), redis_field_redis(name), redis_options(name)
+            )
+          end
+          define_method(:"#\{name}=") do |value|
+            public_send(name).value = value
+          end
+        end
+
+        if options[:global]
+          extend mod
+
+          # dispatch to class methods
+          define_method(name) do
+            self.class.public_send(name)
+          end
+          define_method(:"#\{name}=") do |value|
+            self.class.public_send(:"#\{name}=", value)
+          end
+        else
+          include mod
+        end
+      end
+    end
+  RUBY
+  Redis::Objects.const_set("#{periodical.capitalize}Values", new_module)
+end

--- a/lib/redis/periodical_value.rb
+++ b/lib/redis/periodical_value.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "#{File.dirname(__FILE__)}/recurring_at_intervals"
+require "#{File.dirname(__FILE__)}/base_value_object"
+
+Redis::PERIODICALS.each do |periodical|
+  require "#{File.dirname(__FILE__)}/recurring_at_intervals/#{periodical}"
+
+  new_class = Class.new(Redis::Value) do
+    include Redis::RecurringAtIntervals
+    include Redis::BaseValueObject
+    include const_get("Redis::RecurringAtIntervals::#{periodical.capitalize}")
+  end
+  Redis.const_set("#{periodical.capitalize}Value", new_class)
+end

--- a/redis-objects-periodical.gemspec
+++ b/redis-objects-periodical.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.7.0'
 
-  spec.add_dependency 'redis-objects'
+  spec.add_dependency 'redis-objects', '~> 1.0'
 
   # For more information and examples about making a new gem, checkout our
   # guide at: https://bundler.io/guides/creating_gem.html

--- a/spec/lib/redis/annual_value_spec.rb
+++ b/spec/lib/redis/annual_value_spec.rb
@@ -1,0 +1,209 @@
+# frozen_string_literal: true
+
+RSpec.describe Redis::AnnualValue do
+  let(:mock_class) do
+    Class.new do
+      include Redis::Objects
+
+      annual_value :cache
+
+      def id
+        1
+      end
+    end
+  end
+
+  let(:homepage) { Homepage.new }
+
+  before do
+    stub_const 'Homepage', mock_class
+    Timecop.travel(Time.local(2021, 4, 1))
+    homepage.cache.value = 'a'
+    Timecop.travel(Time.local(2022, 4, 1))
+    homepage.cache.value = 'b'
+    Timecop.travel(Time.local(2023, 4, 1))
+    homepage.cache.value = 'c'
+  end
+
+  context 'with global: true' do
+    let(:mock_class) do
+      Class.new do
+        include Redis::Objects
+
+        annual_value :cache, global: true
+      end
+    end
+
+    let(:homepage) { Homepage }
+
+    it 'supports class-level value of global values' do
+      expect(homepage.redis.get('homepage::cache:2021')).to eq 'a'
+      expect(homepage.redis.get('homepage::cache:2022')).to eq 'b'
+      expect(homepage.redis.get('homepage::cache:2023')).to eq 'c'
+    end
+  end
+
+  describe 'timezone' do
+    before { Timecop.travel(Time.local(2024, 4, 1)) }
+
+    context 'when Time class is extended by Active Support' do
+      it do
+        allow(Time).to receive(:current).and_return(Time.now)
+        homepage.cache = 'd'
+        expect(Time).to have_received(:current).with(no_args)
+      end
+    end
+
+    context 'when Time class is not extended by Active Support' do
+      it do
+        allow(Time).to receive(:now).and_return(Time.now)
+        homepage.cache = 'd'
+        expect(Time).to have_received(:now).with(no_args)
+      end
+    end
+  end
+
+  describe 'keys' do
+    it 'appends new values automatically with the current year' do
+      expect(homepage.redis.get('homepage:1:cache:2021')).to eq 'a'
+      expect(homepage.redis.get('homepage:1:cache:2022')).to eq 'b'
+      expect(homepage.redis.get('homepage:1:cache:2023')).to eq 'c'
+    end
+  end
+
+  describe '#value' do
+    it 'returns the value counted this year' do
+      expect(homepage.cache.value).to eq 'c'
+    end
+  end
+
+  describe '#[]' do
+    context 'with date' do
+      let(:date) { Date.new(2021, 4, 1) }
+
+      it 'returns the value counted the year' do
+        expect(homepage.cache[date]).to eq 'a'
+      end
+    end
+
+    context 'with date and length' do
+      let(:date) { Date.new(2022, 4, 1) }
+
+      it 'returns the values counted within the duration' do
+        expect(homepage.cache[date, 2]).to eq %w[b c]
+      end
+    end
+
+    context 'with date and length (zero)' do
+      let(:date) { Date.new(2022, 4, 1) }
+
+      it 'returns an empty array' do
+        expect(homepage.cache[date, 0]).to eq []
+      end
+    end
+
+    context 'with range of date' do
+      let(:range) do
+        Date.new(2021, 4, 1)..Date.new(2022, 4, 1)
+      end
+
+      it 'returns the values counted within the duration' do
+        expect(homepage.cache[range]).to eq %w[a b]
+      end
+    end
+
+    context 'with time' do
+      let(:time) { Time.local(2021, 4, 1, 10, 20, 30) }
+
+      it 'returns the value counted the year' do
+        expect(homepage.cache[time]).to eq 'a'
+      end
+    end
+
+    context 'with time and length' do
+      let(:time) { Time.local(2022, 4, 1, 10, 20, 30) }
+
+      it 'returns the values counted within the duration' do
+        expect(homepage.cache[time, 2]).to eq %w[b c]
+      end
+    end
+
+    context 'with time and length (zero)' do
+      let(:time) { Time.local(2022, 4, 1, 10, 20, 30) }
+
+      it 'returns an empty array' do
+        expect(homepage.cache[time, 0]).to eq []
+      end
+    end
+
+    context 'with range of time' do
+      let(:range) do
+        Time.local(2021, 4, 1, 10, 20, 30)..Time.local(2022, 4, 1, 10, 20, 30)
+      end
+
+      it 'returns the values counted within the duration' do
+        expect(homepage.cache[range]).to eq %w[a b]
+      end
+    end
+  end
+
+  describe '#delete_at' do
+    context 'with date' do
+      let(:date) { Date.new(2022, 4, 1) }
+
+      it 'deletes the value on the year' do
+        expect { homepage.cache.delete_at(date) }
+          .to change { homepage.cache.at(date).value }
+          .from('b').to(nil)
+      end
+    end
+
+    context 'with time' do
+      let(:time) { Time.local(2022, 4, 1, 10, 20, 30) }
+
+      it 'deletes the value on the year' do
+        expect { homepage.cache.delete_at(time) }
+          .to change { homepage.cache.at(time).value }
+          .from('b').to(nil)
+      end
+    end
+  end
+
+  describe '#range' do
+    context 'with date' do
+      let(:start_date) { Date.new(2021, 4, 1) }
+      let(:end_date) { Date.new(2022, 4, 1) }
+
+      it 'returns the values counted within the duration' do
+        expect(homepage.cache.range(start_date, end_date)).to eq %w[a b]
+      end
+    end
+
+    context 'with time' do
+      let(:start_time) { Time.local(2021, 4, 1, 10, 20, 30) }
+      let(:end_time) { Time.local(2022, 4, 1, 10, 20, 30) }
+
+      it 'returns the values counted within the duration' do
+        expect(homepage.cache.range(start_time, end_time)).to eq %w[a b]
+      end
+    end
+  end
+
+  describe '#at' do
+    context 'with date' do
+      let(:date) { Date.new(2022, 4, 1) }
+
+      it 'returns a value object counted the year' do
+        expect(homepage.cache.at(date).value).to eq 'b'
+      end
+    end
+
+    context 'with time' do
+      let(:time) { Time.local(2022, 4, 1, 10, 20, 30) }
+
+      it 'returns a value object counted the year' do
+        expect(homepage.cache.at(time).value).to eq 'b'
+      end
+    end
+  end
+end

--- a/spec/lib/redis/daily_value_spec.rb
+++ b/spec/lib/redis/daily_value_spec.rb
@@ -1,0 +1,207 @@
+# frozen_string_literal: true
+
+RSpec.describe Redis::DailyValue do
+  let(:mock_class) do
+    Class.new do
+      include Redis::Objects
+
+      daily_value :cache, expiration: 2_678_400 # about a month
+
+      def id
+        1
+      end
+    end
+  end
+
+  let(:homepage) { Homepage.new }
+
+  before do
+    stub_const 'Homepage', mock_class
+    Timecop.travel(Time.local(2021, 4, 1))
+    homepage.cache = 'a'
+    Timecop.travel(Time.local(2021, 4, 2))
+    homepage.cache = 'b'
+    Timecop.travel(Time.local(2021, 4, 3))
+    homepage.cache = 'c'
+  end
+
+  context 'with global: true' do
+    let(:mock_class) do
+      Class.new do
+        include Redis::Objects
+
+        daily_value :cache, global: true
+      end
+    end
+
+    let(:homepage) { Homepage }
+
+    it 'supports class-level increment/decrement of global values' do
+      expect(homepage.redis.get('homepage::cache:2021-04-01')).to eq 'a'
+      expect(homepage.redis.get('homepage::cache:2021-04-02')).to eq 'b'
+      expect(homepage.redis.get('homepage::cache:2021-04-03')).to eq 'c'
+    end
+  end
+
+  describe 'timezone' do
+    context 'when Time class is extended by Active Support' do
+      it do
+        allow(Time).to receive(:current).and_return(Time.now)
+        homepage.cache = 'd'
+        expect(Time).to have_received(:current).with(no_args)
+      end
+    end
+
+    context 'when Time class is not extended by Active Support' do
+      it do
+        allow(Time).to receive(:now).and_return(Time.now)
+        homepage.cache = 'd'
+        expect(Time).to have_received(:now).with(no_args)
+      end
+    end
+  end
+
+  describe 'keys' do
+    it 'appends new values automatically with the current date' do
+      expect(homepage.redis.get('homepage:1:cache:2021-04-01')).to eq 'a'
+      expect(homepage.redis.get('homepage:1:cache:2021-04-02')).to eq 'b'
+      expect(homepage.redis.get('homepage:1:cache:2021-04-03')).to eq 'c'
+    end
+  end
+
+  describe '#value' do
+    it 'returns the value counted today' do
+      expect(homepage.cache.value).to eq 'c'
+    end
+  end
+
+  describe '#[]' do
+    context 'with date' do
+      let(:date) { Date.new(2021, 4, 1) }
+
+      it 'returns the value counted the day' do
+        expect(homepage.cache[date]).to eq 'a'
+      end
+    end
+
+    context 'with date and length' do
+      let(:date) { Date.new(2021, 4, 2) }
+
+      it 'returns the values counted within the duration' do
+        expect(homepage.cache[date, 2]).to eq %w[b c]
+      end
+    end
+
+    context 'with date and length (zero)' do
+      let(:date) { Date.new(2021, 4, 2) }
+
+      it 'returns an empty array' do
+        expect(homepage.cache[date, 0]).to eq []
+      end
+    end
+
+    context 'with range of date' do
+      let(:range) do
+        Date.new(2021, 4, 1)..Date.new(2021, 4, 2)
+      end
+
+      it 'returns the values counted within the duration' do
+        expect(homepage.cache[range]).to eq %w[a b]
+      end
+    end
+
+    context 'with time' do
+      let(:time) { Time.local(2021, 4, 1, 10, 20, 30) }
+
+      it 'returns the value counted the day' do
+        expect(homepage.cache[time]).to eq 'a'
+      end
+    end
+
+    context 'with time and length' do
+      let(:time) { Time.local(2021, 4, 2, 10, 20, 30) }
+
+      it 'returns the values counted within the duration' do
+        expect(homepage.cache[time, 2]).to eq %w[b c]
+      end
+    end
+
+    context 'with time and length (zero)' do
+      let(:time) { Time.local(2021, 4, 2, 10, 20, 30) }
+
+      it 'returns an empty array' do
+        expect(homepage.cache[time, 0]).to eq []
+      end
+    end
+
+    context 'with range of time' do
+      let(:range) do
+        Time.local(2021, 4, 1, 10, 20, 30)..Time.local(2021, 4, 2, 10, 20, 30)
+      end
+
+      it 'returns the values counted within the duration' do
+        expect(homepage.cache[range]).to eq %w[a b]
+      end
+    end
+  end
+
+  describe '#delete_at' do
+    context 'with date' do
+      let(:date) { Date.new(2021, 4, 2) }
+
+      it 'deletes the value on the day' do
+        expect { homepage.cache.delete_at(date) }
+          .to change { homepage.cache.at(date).value }
+          .from('b').to(nil)
+      end
+    end
+
+    context 'with time' do
+      let(:time) { Time.local(2021, 4, 2, 10, 20, 30) }
+
+      it 'deletes the value on the day' do
+        expect { homepage.cache.delete_at(time) }
+          .to change { homepage.cache.at(time).value }
+          .from('b').to(nil)
+      end
+    end
+  end
+
+  describe '#range' do
+    context 'with date' do
+      let(:start_date) { Date.new(2021, 4, 1) }
+      let(:end_date) { Date.new(2021, 4, 2) }
+
+      it 'returns the values counted within the duration' do
+        expect(homepage.cache.range(start_date, end_date)).to eq %w[a b]
+      end
+    end
+
+    context 'with time' do
+      let(:start_time) { Time.local(2021, 4, 1, 10, 20, 30) }
+      let(:end_time) { Time.local(2021, 4, 2, 10, 20, 30) }
+
+      it 'returns the values counted within the duration' do
+        expect(homepage.cache.range(start_time, end_time)).to eq %w[a b]
+      end
+    end
+  end
+
+  describe '#at' do
+    context 'with date' do
+      let(:date) { Date.new(2021, 4, 2) }
+
+      it 'returns a value object counted the day' do
+        expect(homepage.cache.at(date).value).to eq 'b'
+      end
+    end
+
+    context 'with time' do
+      let(:time) { Time.local(2021, 4, 2, 10, 20, 30) }
+
+      it 'returns a value object counted the day' do
+        expect(homepage.cache.at(time).value).to eq 'b'
+      end
+    end
+  end
+end

--- a/spec/lib/redis/hourly_value_spec.rb
+++ b/spec/lib/redis/hourly_value_spec.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+RSpec.describe Redis::HourlyValue do
+  let(:mock_class) do
+    Class.new do
+      include Redis::Objects
+
+      hourly_value :cache, expiration: 86_400 # about a day
+
+      def id
+        1
+      end
+    end
+  end
+
+  let(:homepage) { Homepage.new }
+
+  before do
+    stub_const 'Homepage', mock_class
+    Timecop.travel(Time.local(2021, 4, 1, 10))
+    homepage.cache = 'a'
+    Timecop.travel(Time.local(2021, 4, 1, 11))
+    homepage.cache = 'b'
+    Timecop.travel(Time.local(2021, 4, 1, 12))
+    homepage.cache = 'c'
+  end
+
+  context 'with global: true' do
+    let(:mock_class) do
+      Class.new do
+        include Redis::Objects
+
+        hourly_value :cache, global: true
+      end
+    end
+
+    let(:homepage) { Homepage }
+
+    it 'supports class-level increment/decrement of global values' do
+      expect(homepage.redis.get('homepage::cache:2021-04-01T10')).to eq 'a'
+      expect(homepage.redis.get('homepage::cache:2021-04-01T11')).to eq 'b'
+      expect(homepage.redis.get('homepage::cache:2021-04-01T12')).to eq 'c'
+    end
+  end
+
+  describe 'timezone' do
+    context 'when Time class is extended by Active Support' do
+      it do
+        allow(Time).to receive(:current).and_return(Time.now)
+        homepage.cache = 'd'
+        expect(Time).to have_received(:current).with(no_args)
+      end
+    end
+
+    context 'when Time class is not extended by Active Support' do
+      it do
+        allow(Time).to receive(:now).and_return(Time.now)
+        homepage.cache = 'd'
+        expect(Time).to have_received(:now).with(no_args)
+      end
+    end
+  end
+
+  describe 'keys' do
+    it 'appends new values automatically with the current hour' do
+      expect(homepage.redis.get('homepage:1:cache:2021-04-01T10')).to eq 'a'
+      expect(homepage.redis.get('homepage:1:cache:2021-04-01T11')).to eq 'b'
+      expect(homepage.redis.get('homepage:1:cache:2021-04-01T12')).to eq 'c'
+    end
+  end
+
+  describe '#value' do
+    it 'returns the value counted this hour' do
+      expect(homepage.cache.value).to eq 'c'
+    end
+  end
+
+  describe '#[]' do
+    context 'with time' do
+      let(:time) { Time.local(2021, 4, 1, 10) }
+
+      it 'returns the value counted the hour' do
+        expect(homepage.cache[time]).to eq 'a'
+      end
+    end
+
+    context 'with time and length' do
+      let(:time) { Time.local(2021, 4, 1, 11) }
+
+      it 'returns the values counted within the duration' do
+        expect(homepage.cache[time, 2]).to eq %w[b c]
+      end
+    end
+
+    context 'with time and length (zero)' do
+      let(:time) { Time.local(2021, 4, 1, 11) }
+
+      it 'returns an empty array' do
+        expect(homepage.cache[time, 0]).to eq []
+      end
+    end
+
+    context 'with range' do
+      let(:range) do
+        Time.local(2021, 4, 1, 10)..Time.local(2021, 4, 1, 11)
+      end
+
+      it 'returns the values counted within the duration' do
+        expect(homepage.cache[range]).to eq %w[a b]
+      end
+    end
+  end
+
+  describe '#delete_at' do
+    let(:time) { Time.local(2021, 4, 1, 11) }
+
+    it 'deletes the value on the hour' do
+      expect { homepage.cache.delete_at(time) }
+        .to change { homepage.cache.at(time).value }
+        .from('b').to(nil)
+    end
+  end
+
+  describe '#range' do
+    let(:start_time) { Time.local(2021, 4, 1, 10) }
+    let(:end_time) { Time.local(2021, 4, 1, 11) }
+
+    it 'returns the values counted within the duration' do
+      expect(homepage.cache.range(start_time, end_time)).to eq %w[a b]
+    end
+  end
+
+  describe '#at' do
+    let(:time) { Time.local(2021, 4, 1, 11) }
+
+    it 'returns a value object counted the hour' do
+      expect(homepage.cache.at(time).value).to eq 'b'
+    end
+  end
+end

--- a/spec/lib/redis/minutely_value_spec.rb
+++ b/spec/lib/redis/minutely_value_spec.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+RSpec.describe Redis::MinutelyValue do
+  let(:mock_class) do
+    Class.new do
+      include Redis::Objects
+
+      minutely_value :cache, expiration: 86_400 # about a day
+
+      def id
+        1
+      end
+    end
+  end
+
+  let(:homepage) { Homepage.new }
+
+  before do
+    stub_const 'Homepage', mock_class
+    Timecop.travel(Time.local(2021, 4, 1, 10, 20))
+    homepage.cache.value = 'a'
+    Timecop.travel(Time.local(2021, 4, 1, 10, 21))
+    homepage.cache.value = 'b'
+    Timecop.travel(Time.local(2021, 4, 1, 10, 22))
+    homepage.cache.value = 'c'
+  end
+
+  context 'with global: true' do
+    let(:mock_class) do
+      Class.new do
+        include Redis::Objects
+
+        minutely_value :cache, global: true
+      end
+    end
+
+    let(:homepage) { Homepage }
+
+    it 'supports class-level increment/decrement of global values' do
+      expect(homepage.redis.get('homepage::cache:2021-04-01T10:20')).to eq 'a'
+      expect(homepage.redis.get('homepage::cache:2021-04-01T10:21')).to eq 'b'
+      expect(homepage.redis.get('homepage::cache:2021-04-01T10:22')).to eq 'c'
+    end
+  end
+
+  describe 'timezone' do
+    context 'when Time class is extended by Active Support' do
+      it do
+        allow(Time).to receive(:current).and_return(Time.now)
+        homepage.cache.value = 'd'
+        expect(Time).to have_received(:current).with(no_args)
+      end
+    end
+
+    context 'when Time class is not extended by Active Support' do
+      it do
+        allow(Time).to receive(:now).and_return(Time.now)
+        homepage.cache.value = 'd'
+        expect(Time).to have_received(:now).with(no_args)
+      end
+    end
+  end
+
+  describe 'keys' do
+    it 'appends new values automatically with the current minute' do
+      expect(homepage.redis.get('homepage:1:cache:2021-04-01T10:20')).to eq 'a'
+      expect(homepage.redis.get('homepage:1:cache:2021-04-01T10:21')).to eq 'b'
+      expect(homepage.redis.get('homepage:1:cache:2021-04-01T10:22')).to eq 'c'
+    end
+  end
+
+  describe '#value' do
+    it 'returns the value counted this minute' do
+      expect(homepage.cache.value).to eq 'c'
+    end
+  end
+
+  describe '#[]' do
+    context 'with time' do
+      let(:time) { Time.local(2021, 4, 1, 10, 20) }
+
+      it 'returns the value counted the minute' do
+        expect(homepage.cache[time]).to eq 'a'
+      end
+    end
+
+    context 'with time and length' do
+      let(:time) { Time.local(2021, 4, 1, 10, 21) }
+
+      it 'returns the values counted within the duration' do
+        expect(homepage.cache[time, 2]).to eq %w[b c]
+      end
+    end
+
+    context 'with time and length (zero)' do
+      let(:time) { Time.local(2021, 4, 1, 10, 21) }
+
+      it 'returns an empty array' do
+        expect(homepage.cache[time, 0]).to eq []
+      end
+    end
+
+    context 'with range' do
+      let(:range) do
+        Time.local(2021, 4, 1, 10, 20)..Time.local(2021, 4, 1, 10, 21)
+      end
+
+      it 'returns the values counted within the duration' do
+        expect(homepage.cache[range]).to eq %w[a b]
+      end
+    end
+  end
+
+  describe '#delete_at' do
+    let(:time) { Time.local(2021, 4, 1, 10, 21) }
+
+    it 'deletes the value on the minute' do
+      expect { homepage.cache.delete_at(time) }
+        .to change { homepage.cache.at(time).value }
+        .from('b').to(nil)
+    end
+  end
+
+  describe '#range' do
+    let(:start_time) { Time.local(2021, 4, 1, 10, 20) }
+    let(:end_time) { Time.local(2021, 4, 1, 10, 21) }
+
+    it 'returns the values counted within the duration' do
+      expect(homepage.cache.range(start_time, end_time)).to eq %w[a b]
+    end
+  end
+
+  describe '#at' do
+    let(:time) { Time.local(2021, 4, 1, 10, 21) }
+
+    it 'returns a value object counted the minute' do
+      expect(homepage.cache.at(time).value).to eq 'b'
+    end
+  end
+end

--- a/spec/lib/redis/monthly_value_spec.rb
+++ b/spec/lib/redis/monthly_value_spec.rb
@@ -1,0 +1,207 @@
+# frozen_string_literal: true
+
+RSpec.describe Redis::MonthlyValue do
+  let(:mock_class) do
+    Class.new do
+      include Redis::Objects
+
+      monthly_value :cache
+
+      def id
+        1
+      end
+    end
+  end
+
+  let(:homepage) { Homepage.new }
+
+  before do
+    stub_const 'Homepage', mock_class
+    Timecop.travel(Time.local(2021, 4, 1))
+    homepage.cache.value = 'a'
+    Timecop.travel(Time.local(2021, 5, 1))
+    homepage.cache.value = 'b'
+    Timecop.travel(Time.local(2021, 6, 1))
+    homepage.cache.value = 'c'
+  end
+
+  context 'with global: true' do
+    let(:mock_class) do
+      Class.new do
+        include Redis::Objects
+
+        monthly_value :cache, global: true
+      end
+    end
+
+    let(:homepage) { Homepage }
+
+    it 'supports class-level increment/decrement of global values' do
+      expect(homepage.redis.get('homepage::cache:2021-04')).to eq 'a'
+      expect(homepage.redis.get('homepage::cache:2021-05')).to eq 'b'
+      expect(homepage.redis.get('homepage::cache:2021-06')).to eq 'c'
+    end
+  end
+
+  describe 'timezone' do
+    context 'when Time class is extended by Active Support' do
+      it do
+        allow(Time).to receive(:current).and_return(Time.now)
+        homepage.cache.value = 'd'
+        expect(Time).to have_received(:current).with(no_args)
+      end
+    end
+
+    context 'when Time class is not extended by Active Support' do
+      it do
+        allow(Time).to receive(:now).and_return(Time.now)
+        homepage.cache.value = 'd'
+        expect(Time).to have_received(:now).with(no_args)
+      end
+    end
+  end
+
+  describe 'keys' do
+    it 'appends new values automatically with the current month' do
+      expect(homepage.redis.get('homepage:1:cache:2021-04')).to eq 'a'
+      expect(homepage.redis.get('homepage:1:cache:2021-05')).to eq 'b'
+      expect(homepage.redis.get('homepage:1:cache:2021-06')).to eq 'c'
+    end
+  end
+
+  describe '#value' do
+    it 'returns the value counted this month' do
+      expect(homepage.cache.value).to eq 'c'
+    end
+  end
+
+  describe '#[]' do
+    context 'with date' do
+      let(:date) { Date.new(2021, 4, 1) }
+
+      it 'returns the value counted the month' do
+        expect(homepage.cache[date]).to eq 'a'
+      end
+    end
+
+    context 'with date and length' do
+      let(:date) { Date.new(2021, 5, 1) }
+
+      it 'returns the values counted within the duration' do
+        expect(homepage.cache[date, 2]).to eq %w[b c]
+      end
+    end
+
+    context 'with date and length (zero)' do
+      let(:date) { Date.new(2021, 5, 1) }
+
+      it 'returns an empty array' do
+        expect(homepage.cache[date, 0]).to eq []
+      end
+    end
+
+    context 'with range of date' do
+      let(:range) do
+        Date.new(2021, 4, 1)..Date.new(2021, 5, 1)
+      end
+
+      it 'returns the values counted within the duration' do
+        expect(homepage.cache[range]).to eq %w[a b]
+      end
+    end
+
+    context 'with time' do
+      let(:time) { Time.local(2021, 4, 1, 10, 20, 30) }
+
+      it 'returns the value counted the month' do
+        expect(homepage.cache[time]).to eq 'a'
+      end
+    end
+
+    context 'with time and length' do
+      let(:time) { Time.local(2021, 5, 1, 10, 20, 30) }
+
+      it 'returns the values counted within the duration' do
+        expect(homepage.cache[time, 2]).to eq %w[b c]
+      end
+    end
+
+    context 'with time and length (zero)' do
+      let(:time) { Time.local(2021, 5, 1, 10, 20, 30) }
+
+      it 'returns an empty array' do
+        expect(homepage.cache[time, 0]).to eq []
+      end
+    end
+
+    context 'with range of time' do
+      let(:range) do
+        Time.local(2021, 4, 1, 10, 20, 30)..Time.local(2021, 5, 1, 10, 20, 30)
+      end
+
+      it 'returns the values counted within the duration' do
+        expect(homepage.cache[range]).to eq %w[a b]
+      end
+    end
+  end
+
+  describe '#delete_at' do
+    context 'with date' do
+      let(:date) { Date.new(2021, 5, 1) }
+
+      it 'deletes the value on the month' do
+        expect { homepage.cache.delete_at(date) }
+          .to change { homepage.cache.at(date).value }
+          .from('b').to(nil)
+      end
+    end
+
+    context 'with time' do
+      let(:time) { Time.local(2021, 5, 1, 10, 20, 30) }
+
+      it 'deletes the value on the month' do
+        expect { homepage.cache.delete_at(time) }
+          .to change { homepage.cache.at(time).value }
+          .from('b').to(nil)
+      end
+    end
+  end
+
+  describe '#range' do
+    context 'with date' do
+      let(:start_date) { Date.new(2021, 4, 1) }
+      let(:end_date) { Date.new(2021, 5, 1) }
+
+      it 'returns the values counted within the duration' do
+        expect(homepage.cache.range(start_date, end_date)).to eq %w[a b]
+      end
+    end
+
+    context 'with time' do
+      let(:start_time) { Time.local(2021, 4, 1, 10, 20, 30) }
+      let(:end_time) { Time.local(2021, 5, 1, 10, 20, 30) }
+
+      it 'returns the values counted within the duration' do
+        expect(homepage.cache.range(start_time, end_time)).to eq %w[a b]
+      end
+    end
+  end
+
+  describe '#at' do
+    context 'with date' do
+      let(:date) { Date.new(2021, 5, 1) }
+
+      it 'returns a value object counted the month' do
+        expect(homepage.cache.at(date).value).to eq 'b'
+      end
+    end
+
+    context 'with time' do
+      let(:time) { Time.local(2021, 5, 1, 10, 20, 30) }
+
+      it 'returns a value object counted the month' do
+        expect(homepage.cache.at(time).value).to eq 'b'
+      end
+    end
+  end
+end

--- a/spec/lib/redis/weekly_value_spec.rb
+++ b/spec/lib/redis/weekly_value_spec.rb
@@ -1,0 +1,207 @@
+# frozen_string_literal: true
+
+RSpec.describe Redis::WeeklyValue do
+  let(:mock_class) do
+    Class.new do
+      include Redis::Objects
+
+      weekly_value :cache, expiration: 2_678_400 # about a month
+
+      def id
+        1
+      end
+    end
+  end
+
+  let(:homepage) { Homepage.new }
+
+  before do
+    stub_const 'Homepage', mock_class
+    Timecop.travel(Time.local(2021, 4, 1))
+    homepage.cache.value = 'a'
+    Timecop.travel(Time.local(2021, 4, 8))
+    homepage.cache.value = 'b'
+    Timecop.travel(Time.local(2021, 4, 15))
+    homepage.cache.value = 'c'
+  end
+
+  context 'with global: true' do
+    let(:mock_class) do
+      Class.new do
+        include Redis::Objects
+
+        weekly_value :cache, global: true
+      end
+    end
+
+    let(:homepage) { Homepage }
+
+    it 'supports class-level increment/decrement of global values' do
+      expect(homepage.redis.get('homepage::cache:2021W13')).to eq 'a'
+      expect(homepage.redis.get('homepage::cache:2021W14')).to eq 'b'
+      expect(homepage.redis.get('homepage::cache:2021W15')).to eq 'c'
+    end
+  end
+
+  describe 'timezone' do
+    context 'when Time class is extended by Active Support' do
+      it do
+        allow(Time).to receive(:current).and_return(Time.now)
+        homepage.cache.value = 'd'
+        expect(Time).to have_received(:current).with(no_args)
+      end
+    end
+
+    context 'when Time class is not extended by Active Support' do
+      it do
+        allow(Time).to receive(:now).and_return(Time.now)
+        homepage.cache.value = 'd'
+        expect(Time).to have_received(:now).with(no_args)
+      end
+    end
+  end
+
+  describe 'keys' do
+    it 'appends new values automatically with the current week' do
+      expect(homepage.redis.get('homepage:1:cache:2021W13')).to eq 'a'
+      expect(homepage.redis.get('homepage:1:cache:2021W14')).to eq 'b'
+      expect(homepage.redis.get('homepage:1:cache:2021W15')).to eq 'c'
+    end
+  end
+
+  describe '#value' do
+    it 'returns the value counted this week' do
+      expect(homepage.cache.value).to eq 'c'
+    end
+  end
+
+  describe '#[]' do
+    context 'with date' do
+      let(:date) { Date.new(2021, 4, 1) }
+
+      it 'returns the value counted the week' do
+        expect(homepage.cache[date]).to eq 'a'
+      end
+    end
+
+    context 'with date and length' do
+      let(:date) { Date.new(2021, 4, 8) }
+
+      it 'returns the values counted within the duration' do
+        expect(homepage.cache[date, 2]).to eq %w[b c]
+      end
+    end
+
+    context 'with date and length (zero)' do
+      let(:date) { Date.new(2022, 4, 1) }
+
+      it 'returns an empty array' do
+        expect(homepage.cache[date, 0]).to eq []
+      end
+    end
+
+    context 'with range of date' do
+      let(:range) do
+        Date.new(2021, 4, 1)..Date.new(2021, 4, 8)
+      end
+
+      it 'returns the values counted within the duration' do
+        expect(homepage.cache[range]).to eq %w[a b]
+      end
+    end
+
+    context 'with time' do
+      let(:time) { Time.local(2021, 4, 1, 10, 20, 30) }
+
+      it 'returns the value counted the week' do
+        expect(homepage.cache[time]).to eq 'a'
+      end
+    end
+
+    context 'with time and length' do
+      let(:time) { Time.local(2021, 4, 8, 10, 20, 30) }
+
+      it 'returns the values counted within the duration' do
+        expect(homepage.cache[time, 2]).to eq %w[b c]
+      end
+    end
+
+    context 'with time and length (zero)' do
+      let(:time) { Time.local(2022, 4, 1, 10, 20, 30) }
+
+      it 'returns an empty array' do
+        expect(homepage.cache[time, 0]).to eq []
+      end
+    end
+
+    context 'with range of time' do
+      let(:range) do
+        Time.local(2021, 4, 1, 10, 20, 30)..Time.local(2021, 4, 8, 10, 20, 30)
+      end
+
+      it 'returns the values counted within the duration' do
+        expect(homepage.cache[range]).to eq %w[a b]
+      end
+    end
+  end
+
+  describe '#delete_at' do
+    context 'with date' do
+      let(:date) { Date.new(2021, 4, 8) }
+
+      it 'deletes the value on the week' do
+        expect { homepage.cache.delete_at(date) }
+          .to change { homepage.cache.at(date).value }
+          .from('b').to(nil)
+      end
+    end
+
+    context 'with time' do
+      let(:time) { Time.local(2021, 4, 8, 10, 20, 30) }
+
+      it 'deletes the value on the week' do
+        expect { homepage.cache.delete_at(time) }
+          .to change { homepage.cache.at(time).value }
+          .from('b').to(nil)
+      end
+    end
+  end
+
+  describe '#range' do
+    context 'with date' do
+      let(:start_date) { Date.new(2021, 4, 1) }
+      let(:end_date) { Date.new(2021, 4, 8) }
+
+      it 'returns the values counted within the duration' do
+        expect(homepage.cache.range(start_date, end_date)).to eq %w[a b]
+      end
+    end
+
+    context 'with time' do
+      let(:start_time) { Time.local(2021, 4, 1, 10, 20, 30) }
+      let(:end_time) { Time.local(2021, 4, 8, 10, 20, 30) }
+
+      it 'returns the values counted within the duration' do
+        expect(homepage.cache.range(start_time, end_time)).to eq %w[a b]
+      end
+    end
+  end
+
+  describe '#at' do
+    context 'with date' do
+      let(:date) { Date.new(2021, 4, 8) }
+
+      it 'returns a value object counted the week' do
+        expect(homepage.cache.at(date).value).to eq 'b'
+      end
+    end
+
+    context 'with time' do
+      let(:time) { Time.local(2021, 4, 8, 10, 20, 30) }
+
+      it 'returns a value object counted the week' do
+        expect(homepage.cache.at(time).value).to eq 'b'
+      end
+    end
+  end
+end


### PR DESCRIPTION
The periodical values automatically switches the save destination when the date changes.

```rb
class Homepage
  include Redis::Objects

  daily_value :cache, expireat: -> { Time.now + 2_678_400 } # about a month

  def id
    1
  end
end

homepage = Homepage.new

# 2021-04-01
homepage.cache.value = 'a'

# 2021-04-02 (next day)
homepage.cache.value = 'b'

# 2021-04-03 (next day)
homepage.cache.value = 'c'

homepage.cache[Date.new(2021, 4, 1)] # => 'a'
homepage.cache[Date.new(2021, 4, 1), 3] # => ['a', 'b', 'c']
homepage.cache[Date.new(2021, 4, 1)..Date.new(2021, 4, 2)] # => ['a', 'b']

homepage.cache.delete_at(Date.new(2021, 4, 1))
homepage.cache.range(Date.new(2021, 4, 1), Date.new(2021, 4, 3)) # => [nil, 'b', 'c']
homepage.cache.at(Date.new(2021, 4, 2)) # => #<Redis::Value key="homepage:1:cache:2021-04-02">
homepage.cache.at(Date.new(2021, 4, 2)).value # 'b'
```